### PR TITLE
fix(pi): accept thinking level changed events

### DIFF
--- a/crates/pi-bridge/src/pool/pi_protocol.rs
+++ b/crates/pi-bridge/src/pool/pi_protocol.rs
@@ -570,6 +570,9 @@ pub enum PiEvent {
         #[serde(rename = "toolResults")]
         tool_results: Vec<ToolResultMessage>,
     },
+    ThinkingLevelChanged {
+        level: ThinkingLevel,
+    },
 
     // Message lifecycle
     MessageStart {
@@ -1441,6 +1444,32 @@ mod tests {
         match serde_json::from_value::<PiOutboundMessage>(evt).unwrap() {
             PiOutboundMessage::Event(PiEvent::AgentStart) => {}
             _ => panic!("agent_start misclassified"),
+        }
+    }
+
+    #[test]
+    fn thinking_level_changed_event_round_trips() {
+        for level in [
+            ThinkingLevel::Off,
+            ThinkingLevel::Minimal,
+            ThinkingLevel::Low,
+            ThinkingLevel::Medium,
+            ThinkingLevel::High,
+            ThinkingLevel::Xhigh,
+        ] {
+            let event = PiEvent::ThinkingLevelChanged { level };
+            let body = serde_json::to_value(&event).unwrap();
+            assert_eq!(
+                body.get("type").and_then(Value::as_str),
+                Some("thinking_level_changed")
+            );
+
+            match serde_json::from_value::<PiOutboundMessage>(body).unwrap() {
+                PiOutboundMessage::Event(PiEvent::ThinkingLevelChanged { level: parsed }) => {
+                    assert_eq!(parsed, level);
+                }
+                _ => panic!("thinking_level_changed misclassified"),
+            }
         }
     }
 

--- a/crates/pi-bridge/src/translate/events.rs
+++ b/crates/pi-bridge/src/translate/events.rs
@@ -99,6 +99,7 @@ impl EventTranslatorState {
             PiEvent::TurnStart => Vec::new(),
             PiEvent::AgentEnd { .. } => self.translate_agent_end(),
             PiEvent::TurnEnd { .. } => Vec::new(),
+            PiEvent::ThinkingLevelChanged { .. } => Vec::new(),
 
             PiEvent::MessageStart { message } => match message {
                 AgentMessage::Assistant(a) => self.translate_message_start(a),


### PR DESCRIPTION
## Summary

Adds protocol support for Pi's `thinking_level_changed` event and treats it as a no-op when translating Pi events to Codex events.

## Problem

Pi can emit a stdout event with:

```json
{ "type": "thinking_level_changed", "level": "..." }
```

The Alleycat Pi bridge models Pi stdout as either an RPC response or a typed `PiEvent`. Before this change, `thinking_level_changed` was not part of the `PiEvent` enum, so the reader could not deserialize that event cleanly and would log/drop it as an unknown line.

That made the bridge unnecessarily brittle against a valid Pi session event.

## Fix

- Adds `PiEvent::ThinkingLevelChanged { level: ThinkingLevel }`.
- Adds an explicit translator no-op because this event does not map to a Codex stream event.
- Adds a round-trip test for every `ThinkingLevel` variant to ensure the event is classified as a Pi event, not rejected or misclassified.

## Reproduction

Protocol-level reproduction:

1. Build a Pi outbound event shaped as `{"type":"thinking_level_changed","level":"high"}`.
2. Deserialize it as `PiOutboundMessage`.
3. Before this fix, the event was not represented in the `PiEvent` tagged enum.
4. After this fix, it deserializes as `PiOutboundMessage::Event(PiEvent::ThinkingLevelChanged { ... })`.

## Testing

Verified in Docker:

```sh
docker run --rm \
  -v "$PWD":/workspace \
  -v alleycat-cargo-registry:/usr/local/cargo/registry \
  -v alleycat-cargo-git:/usr/local/cargo/git \
  -v alleycat-target:/workspace/target \
  -w /workspace \
  rust:1.90 \
  cargo test -p alleycat-pi-bridge thinking_level_changed_event_round_trips
```

Result: passed.
