### PR TITLE
fix(pi): avoid resume switch race

### DIFF
--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -230,34 +230,39 @@ pub async fn handle_thread_resume(
         .ok_or_else(|| ThreadError::NotFound(params.thread_id.clone()))?;
 
     let cwd = resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
-    let handle = match state.pi_pool().get(&params.thread_id).await {
-        Some(h) => h,
-        None => state
-            .pi_pool()
-            .acquire_for_resume(params.thread_id.clone(), &cwd)
-            .await
-            .map_err(ThreadError::pool)?,
+    let (handle, already_loaded) = match state.pi_pool().get(&params.thread_id).await {
+        Some(h) => (h, true),
+        None => (
+            state
+                .pi_pool()
+                .acquire_for_resume(params.thread_id.clone(), &cwd)
+                .await
+                .map_err(ThreadError::pool)?,
+            false,
+        ),
     };
 
-    // Switch the spawned process to the persisted pi session file so
-    // future commands write to the right JSONL.
-    let switch = handle
-        .send_request(pi::RpcCommand::SwitchSession(pi::SwitchSessionCmd {
-            id: None,
-            session_path: entry
-                .metadata
-                .pi_session_path
-                .to_string_lossy()
-                .into_owned(),
-        }))
-        .await
-        .map_err(|e| ThreadError::PiRpc(e.to_string()))?;
-    if !switch.success {
-        return Err(ThreadError::PiRpc(
-            switch
-                .error
-                .unwrap_or_else(|| "switch_session failed".into()),
-        ));
+    if !already_loaded {
+        // A loaded handle is already on this session. Clients may race
+        // thread/resume with turn/start; do not switch during an active prompt.
+        let switch = handle
+            .send_request(pi::RpcCommand::SwitchSession(pi::SwitchSessionCmd {
+                id: None,
+                session_path: entry
+                    .metadata
+                    .pi_session_path
+                    .to_string_lossy()
+                    .into_owned(),
+            }))
+            .await
+            .map_err(|e| ThreadError::PiRpc(e.to_string()))?;
+        if !switch.success {
+            return Err(ThreadError::PiRpc(
+                switch
+                    .error
+                    .unwrap_or_else(|| "switch_session failed".into()),
+            ));
+        }
     }
 
     apply_model_override(&handle, &params.model, &params.model_provider).await;


### PR DESCRIPTION
## Summary

Prevents `thread/resume` from sending `switch_session` to a Pi process that is already loaded for the requested thread.

## Problem

Pi sessions opened through Alleycat could get stuck on "thinking" after a prompt when the client resumed the same thread while a turn was already active.

The failure reproduced against a live Alleycat daemon with this request pattern:

1. Start a Pi thread.
2. Start a Pi turn.
3. Immediately send duplicate `thread/resume` requests for the same thread.

In the failing case, the turn stream emitted the user message and `turn/start` response, then went quiet. Follow-up reads showed the thread as idle with no turns, and the indexed Pi session path did not exist on disk.

## Root Cause

`handle_thread_resume` always sent Pi `switch_session` after obtaining a handle.

That is correct when `thread/resume` spawns a fresh Pi process for a persisted session. It is unsafe when the handle is already loaded and may have an active `turn/start`; in that case the process is already on the right session, and switching during the active prompt can race the turn.

## Fix

`thread/resume` now distinguishes between:

- existing loaded handle: do not call `switch_session`
- newly acquired resume handle: call `switch_session` as before

This preserves persisted resume behavior while avoiding session switching during an active prompt.

## Reproduction

Manual reproduction:

```sh
alleycat probe --agent pi --method thread/start \
  --params '{"cwd":"<repo-or-working-directory>"}'

alleycat probe --agent pi --method turn/start \
  --params '{"threadId":"<thread-id>","input":[{"type":"text","text":"Write a detailed five paragraph explanation of why short replies can still be correct. Do not use tools. End with the word DONE."}]}'

alleycat probe --agent pi --method thread/resume \
  --params '{"threadId":"<thread-id>","excludeTurns":false}'

alleycat probe --agent pi --method thread/resume \
  --params '{"threadId":"<thread-id>","excludeTurns":false}'
```

Broken post-state before the fix:

```sh
alleycat probe --agent pi --method thread/read \
  --params '{"threadId":"<thread-id>","includeTurns":true}'

alleycat probe --agent pi --method thread/turns/list \
  --params '{"threadId":"<thread-id>"}'
```

Observed before the fix:

- `thread/read` returned an idle thread with `turns: []`.
- `thread/turns/list` returned no turns.
- The indexed `piSessionPath` did not exist on disk.

## Testing

Verified in Docker:

```sh
docker run --rm \
  -v "$PWD":/workspace \
  -v alleycat-cargo-registry:/usr/local/cargo/registry \
  -v alleycat-cargo-git:/usr/local/cargo/git \
  -v alleycat-target:/workspace/target \
  -w /workspace \
  rust:1.90 \
  cargo test -p alleycat-pi-bridge --test v3_resume
```

Result: passed.

The existing `v3_resume` test verifies the persisted resume path still works. The active-turn race was reproduced manually through `alleycat probe`; adding an automated race regression test remains a follow-up.
