### PR TITLE
opencode: include commandActions for bash history

### DIFF
--- a/crates/opencode-bridge/src/translate/tool.rs
+++ b/crates/opencode-bridge/src/translate/tool.rs
@@ -61,6 +61,7 @@ pub fn tool_part_to_item_with_context(part: &Value, context: ToolPartContext<'_>
             "command": command,
             "cwd": resolved_cwd(&input, context),
             "status": command_status(status),
+            "commandActions": [],
             "aggregatedOutput": cap_output(extract_text_output(&state)),
         });
         add_exit_code(&mut item, &state);
@@ -732,6 +733,7 @@ mod tests {
         let item = tool_part_to_item(&p).unwrap();
         assert_eq!(item["type"], "commandExecution");
         assert_eq!(item["command"], "echo hi");
+        assert_eq!(item["commandActions"], json!([]));
         assert_eq!(item["aggregatedOutput"], "hi\n");
     }
 
@@ -943,6 +945,7 @@ mod tests {
         assert_eq!(item["status"], "failed");
         assert_eq!(item["exitCode"], 1);
         assert_eq!(item["durationMs"], 250);
+        assert_eq!(item["commandActions"], json!([]));
         assert_eq!(item["aggregatedOutput"], "boom");
     }
 

--- a/crates/opencode-bridge/tests/v3_resume.rs
+++ b/crates/opencode-bridge/tests/v3_resume.rs
@@ -98,3 +98,75 @@ async fn thread_resume_then_read_returns_persisted_turns() {
 
     fx.shutdown().await;
 }
+
+#[tokio::test]
+async fn thread_resume_with_bash_history_keeps_command_actions_field() {
+    let state = std::sync::Arc::new(std::sync::Mutex::new(FakeServerState::default()));
+    {
+        let mut guard = state.lock().unwrap();
+        guard.route(
+            "GET /session?directory=%2Ftmp%2Fv3r-bash",
+            json!([{
+                "id":"ses_resume_bash",
+                "directory":"/tmp/v3r-bash",
+                "title":"V3-Resume Bash",
+                "time":{"created":1_000,"updated":1_000}
+            }]),
+        );
+        guard.route(
+            "GET /session/ses_resume_bash/message",
+            json!([
+                {
+                    "info": {"id":"msg_user","role":"user","sessionID":"ses_resume_bash"},
+                    "parts": [{"id":"p1","type":"text","text":"run ls"}]
+                },
+                {
+                    "info": {"id":"msg_asst","role":"assistant","sessionID":"ses_resume_bash"},
+                    "parts": [{
+                        "id":"p_bash","type":"tool","callID":"call_bash","tool":"bash",
+                        "state":{
+                            "status":"completed",
+                            "input":{"command":"ls","cwd":"/tmp/v3r-bash"},
+                            "output":"a\nb\n"
+                        }
+                    }]
+                }
+            ]),
+        );
+    }
+
+    let mut fx = bring_up_bridge("v3r-bash", state.clone()).await;
+
+    send(
+        &mut fx.write,
+        2,
+        "thread/list",
+        json!({"cwd":"/tmp/v3r-bash"}),
+    )
+    .await;
+    let list = read_until_response(&mut fx.read, 2).await;
+    let thread_id = list["result"]["data"][0]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    send(
+        &mut fx.write,
+        3,
+        "thread/resume",
+        json!({"threadId":thread_id}),
+    )
+    .await;
+    let resume = read_until_response(&mut fx.read, 3).await;
+    let turns = resume["result"]["thread"]["turns"]
+        .as_array()
+        .expect("turns array");
+    assert_eq!(turns.len(), 1);
+    let items = turns[0]["items"].as_array().expect("turn items");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[1]["type"], "commandExecution");
+    assert_eq!(items[1]["command"], "ls");
+    assert_eq!(items[1]["commandActions"], json!([]));
+
+    fx.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- include `commandActions: []` when translating OpenCode `bash` tool history into `commandExecution`
- add a `thread/resume` regression test covering historical OpenCode bash history
- strengthen existing tool translation assertions for bash command items

## Why
Opening some historical OpenCode sessions in Litter iOS fails during `thread/resume` with a typed deserialization error because the bridge emits a `commandExecution` item without the required `commandActions` field.

Fixes #10.

## Testing
- `cargo test -p alleycat-opencode-bridge --test v3_resume --test v7_tool_call_surfacing`