### PR TITLE
Improve Pi bridge replay and metadata compatibility

### DIFF
--- a/crates/alleycat/src/agent_manifest.rs
+++ b/crates/alleycat/src/agent_manifest.rs
@@ -25,6 +25,8 @@ pub struct AgentManifest {
     pub visible_modes: Option<&'static [&'static str]>,
     pub supports_ssh_bridge: bool,
     pub uses_direct_codex_port: bool,
+    pub supports_thread_permission_overrides: bool,
+    pub reports_effective_thread_permissions: bool,
 }
 
 impl AgentManifest {
@@ -46,6 +48,8 @@ impl AgentManifest {
                 .map(|modes| modes.iter().map(|s| (*s).to_owned()).collect()),
             supports_ssh_bridge: self.supports_ssh_bridge,
             uses_direct_codex_port: self.uses_direct_codex_port,
+            supports_thread_permission_overrides: self.supports_thread_permission_overrides,
+            reports_effective_thread_permissions: self.reports_effective_thread_permissions,
         }
     }
 }
@@ -64,6 +68,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: true,
         uses_direct_codex_port: true,
+        supports_thread_permission_overrides: true,
+        reports_effective_thread_permissions: true,
     },
     AgentManifest {
         name: "pi",
@@ -78,6 +84,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: true,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
     AgentManifest {
         name: "amp",
@@ -92,6 +100,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: Some(&["smart", "rush", "deep"]),
         supports_ssh_bridge: false,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
     AgentManifest {
         name: "opencode",
@@ -106,6 +116,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: true,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
     AgentManifest {
         name: "claude",
@@ -120,6 +132,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: true,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
     AgentManifest {
         name: "droid",
@@ -134,6 +148,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: false,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
     AgentManifest {
         name: "hermes",
@@ -148,6 +164,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: false,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
     AgentManifest {
         name: "devin",
@@ -162,6 +180,8 @@ pub const MANIFESTS: &[AgentManifest] = &[
         visible_modes: None,
         supports_ssh_bridge: true,
         uses_direct_codex_port: false,
+        supports_thread_permission_overrides: false,
+        reports_effective_thread_permissions: false,
     },
 ];
 

--- a/crates/alleycat/src/cli/probe.rs
+++ b/crates/alleycat/src/cli/probe.rs
@@ -26,7 +26,7 @@ use crate::cli;
 use crate::daemon::control::Request as ControlRequest;
 use crate::framing::{read_json_frame, write_json_frame};
 use crate::host;
-use crate::protocol::{ALLEYCAT_ALPN, PROTOCOL_VERSION, PairPayload, Request, Response};
+use crate::protocol::{ALLEYCAT_ALPN, PROTOCOL_VERSION, PairPayload, Request, Response, Resume};
 
 #[derive(Args, Debug)]
 pub struct ProbeArgs {
@@ -61,6 +61,17 @@ pub struct ProbeArgs {
     /// Timeout for the JSON-RPC method response, in seconds.
     #[arg(long, default_value_t = 30)]
     pub timeout_secs: u64,
+    /// Send an explicit alleycat resume cursor on connect. Useful for
+    /// debugging reconnect/replay behavior; clients normally use the highest
+    /// `_alleycat_seq` they observed before reconnecting.
+    #[arg(long)]
+    pub resume_from: Option<u64>,
+    /// After the first probe finishes, open a second connect stream on the
+    /// same iroh connection with this resume cursor. This simulates a client
+    /// reconnect from the same endpoint identity, so the host can attach the
+    /// existing session and exercise replay/drift paths.
+    #[arg(long)]
+    pub repeat_resume_from: Option<u64>,
 }
 
 pub async fn run(args: ProbeArgs) -> anyhow::Result<()> {
@@ -137,7 +148,14 @@ async fn probe_with_endpoint(
 
     let result = match args.agent.as_deref() {
         None => list_agents(&conn, token).await,
-        Some(agent) => probe_agent(&conn, token, agent, args).await,
+        Some(agent) => {
+            probe_agent(&conn, token, agent, args, args.resume_from).await?;
+            if let Some(resume_from) = args.repeat_resume_from {
+                eprintln!("probe: opening second connect stream with resume_from={resume_from}");
+                probe_agent(&conn, token, agent, args, Some(resume_from)).await?;
+            }
+            Ok(())
+        }
     };
     conn.close(iroh::endpoint::VarInt::from_u32(0), b"probe complete");
     result
@@ -175,6 +193,7 @@ async fn probe_agent(
     token: &str,
     agent: &str,
     args: &ProbeArgs,
+    resume_from: Option<u64>,
 ) -> anyhow::Result<()> {
     let method = args
         .method
@@ -193,7 +212,7 @@ async fn probe_agent(
             v: PROTOCOL_VERSION,
             token: token.to_string(),
             agent: agent.to_string(),
-            resume: None,
+            resume: resume_from.map(|last_seq| Resume { last_seq }),
         },
     )
     .await?;
@@ -208,7 +227,17 @@ async fn probe_agent(
             resp.error.unwrap_or_else(|| "<no error>".to_string())
         );
     }
-    eprintln!("probe: connect ok agent={agent}; switching to JSONL");
+    if let Some(session) = resp.session.as_ref() {
+        eprintln!(
+            "probe: connect ok agent={agent} attached={:?} current_seq={} floor_seq={} resume_from={:?}; switching to JSONL",
+            session.attached, session.current_seq, session.floor_seq, resume_from
+        );
+    } else {
+        eprintln!(
+            "probe: connect ok agent={agent} resume_from={:?}; switching to JSONL",
+            resume_from
+        );
+    }
 
     let mut reader = BufReader::new(recv);
 

--- a/crates/alleycat/src/protocol.rs
+++ b/crates/alleycat/src/protocol.rs
@@ -86,6 +86,17 @@ pub struct AgentCapabilities {
     /// be dialed directly on its TCP port without going through Alleycat.
     #[serde(default)]
     pub uses_direct_codex_port: bool,
+    /// Whether a client may send per-thread approval/sandbox overrides and
+    /// expect the runtime to enforce them. False for bridges that launch in a
+    /// fixed/yolo-like mode or whose upstream agent has no thread permission
+    /// profile system.
+    #[serde(default)]
+    pub supports_thread_permission_overrides: bool,
+    /// Whether thread snapshots from this agent contain authoritative
+    /// effective approval/sandbox policies. False means clients should not
+    /// hydrate or imply permissions from missing/placeholder values.
+    #[serde(default)]
+    pub reports_effective_thread_permissions: bool,
 }
 
 /// Resume hint sent on `Connect` when a reconnecting client wants to

--- a/crates/pi-bridge/src/handlers/model.rs
+++ b/crates/pi-bridge/src/handlers/model.rs
@@ -16,6 +16,7 @@
 //! `mock/experimentalMethod` are inlined in `main.rs`'s dispatcher; this
 //! module deliberately does not duplicate them.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -24,6 +25,9 @@ use serde_json::json;
 use crate::codex_proto as p;
 use crate::pool::pi_protocol as pi;
 use crate::state::ConnectionState;
+
+const PI_SETTINGS_PATH_ENV: &str = "PI_AGENT_SETTINGS_PATH";
+const THINKING_SUFFIXES: &[&str] = &["off", "minimal", "low", "medium", "high", "xhigh"];
 
 pub async fn handle_model_list(
     state: &Arc<ConnectionState>,
@@ -54,7 +58,7 @@ async fn fetch_models_via_pool(state: &Arc<ConnectionState>) -> Vec<PiAvailableM
         }
     };
     match fetch_models_from_handle(&handle).await {
-        Ok(models) => models,
+        Ok(models) => filter_models_by_enabled_models(models),
         Err(err) => {
             tracing::warn!(%err, "model/list: get_available_models RPC failed");
             Vec::new()
@@ -125,6 +129,141 @@ fn translate_pi_model(model: &PiAvailableModel, is_default: bool) -> p::Model {
         service_tiers: standard_service_tiers(),
         is_default,
     }
+}
+
+fn filter_models_by_enabled_models(models: Vec<PiAvailableModel>) -> Vec<PiAvailableModel> {
+    let Some(patterns) = enabled_model_patterns_from_settings() else {
+        return models;
+    };
+    let filtered: Vec<PiAvailableModel> = models
+        .iter()
+        .filter(|model| model_matches_enabled_patterns(model, &patterns))
+        .cloned()
+        .collect();
+    tracing::info!(
+        before = models.len(),
+        after = filtered.len(),
+        patterns = patterns.len(),
+        "model/list: applied pi enabledModels filter"
+    );
+    filtered
+}
+
+fn enabled_model_patterns_from_settings() -> Option<Vec<String>> {
+    let path = pi_settings_path()?;
+    let bytes = std::fs::read_to_string(&path).ok()?;
+    let value: Value = serde_json::from_str(&bytes).ok()?;
+    let patterns = value.get("enabledModels")?.as_array()?;
+    Some(
+        patterns
+            .iter()
+            .filter_map(|pattern| pattern.as_str())
+            .map(str::trim)
+            .filter(|pattern| !pattern.is_empty())
+            .map(strip_thinking_suffix)
+            .collect(),
+    )
+}
+
+fn pi_settings_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var(PI_SETTINGS_PATH_ENV) {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".pi/agent/settings.json"))
+}
+
+fn strip_thinking_suffix(pattern: &str) -> String {
+    let Some((head, suffix)) = pattern.rsplit_once(':') else {
+        return pattern.to_string();
+    };
+    if THINKING_SUFFIXES
+        .iter()
+        .any(|known| suffix.eq_ignore_ascii_case(known))
+    {
+        head.to_string()
+    } else {
+        pattern.to_string()
+    }
+}
+
+fn model_matches_enabled_patterns(model: &PiAvailableModel, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| model_matches_enabled_pattern(model, pattern))
+}
+
+fn model_matches_enabled_pattern(model: &PiAvailableModel, pattern: &str) -> bool {
+    let normalized = pattern.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+    let refs = model_reference_candidates(model);
+    if normalized.contains('*') || normalized.contains('?') {
+        refs.iter()
+            .any(|candidate| wildcard_match(&normalized, candidate))
+    } else {
+        refs.iter().any(|candidate| candidate == &normalized)
+    }
+}
+
+fn model_reference_candidates(model: &PiAvailableModel) -> Vec<String> {
+    let provider = model.provider.as_deref().unwrap_or("pi");
+    let mut refs = Vec::new();
+    for id in [model.model_id.as_deref(), model.id.as_deref()]
+        .into_iter()
+        .flatten()
+    {
+        push_ref(&mut refs, &format!("{provider}/{id}"));
+        if !id.contains('/') {
+            push_ref(&mut refs, id);
+        }
+        if let Some(tail) = id.rsplit('/').next() {
+            push_ref(&mut refs, &format!("{provider}/{tail}"));
+            push_ref(&mut refs, tail);
+        }
+    }
+    refs
+}
+
+fn push_ref(refs: &mut Vec<String>, value: &str) {
+    let normalized = value.trim().to_ascii_lowercase();
+    if !normalized.is_empty() && !refs.contains(&normalized) {
+        refs.push(normalized);
+    }
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    wildcard_match_bytes(pattern.as_bytes(), value.as_bytes())
+}
+
+fn wildcard_match_bytes(pattern: &[u8], value: &[u8]) -> bool {
+    let (mut p, mut v) = (0, 0);
+    let mut star = None;
+    let mut star_match = 0;
+    while v < value.len() {
+        if p < pattern.len() && (pattern[p] == b'?' || pattern[p] == value[v]) {
+            p += 1;
+            v += 1;
+        } else if p < pattern.len() && pattern[p] == b'*' {
+            star = Some(p);
+            p += 1;
+            star_match = v;
+        } else if let Some(star_idx) = star {
+            p = star_idx + 1;
+            star_match += 1;
+            v = star_match;
+        } else {
+            return false;
+        }
+    }
+    while p < pattern.len() && pattern[p] == b'*' {
+        p += 1;
+    }
+    p == pattern.len()
 }
 
 fn standard_service_tiers() -> Vec<p::ModelServiceTier> {
@@ -272,6 +411,44 @@ mod tests {
         assert_eq!(parsed[0].provider.as_deref(), Some("anthropic"));
         assert_eq!(parsed[0].model_id.as_deref(), Some("claude-sonnet-4-6"));
         assert_eq!(parsed[1].id.as_deref(), Some("gpt-5"));
+    }
+
+    #[test]
+    fn enabled_model_filter_matches_full_ids_suffixes_and_globs() {
+        let model = PiAvailableModel {
+            provider: Some("fireworks".into()),
+            model_id: Some("accounts/fireworks/models/deepseek-v4-pro".into()),
+            ..Default::default()
+        };
+        assert!(model_matches_enabled_pattern(
+            &model,
+            "fireworks/accounts/fireworks/models/deepseek-v4-pro"
+        ));
+        assert!(!model_matches_enabled_pattern(
+            &model,
+            "opencode-go/deepseek-v4-pro"
+        ));
+        assert!(model_matches_enabled_pattern(
+            &model,
+            "fireworks/*deepseek-v4*"
+        ));
+        assert!(!model_matches_enabled_pattern(
+            &model,
+            "accounts/fireworks/models/deepseek-v4-pro"
+        ));
+        assert!(!model_matches_enabled_pattern(&model, "openai/gpt-5"));
+    }
+
+    #[test]
+    fn strip_thinking_suffix_leaves_colon_model_ids_alone() {
+        assert_eq!(
+            strip_thinking_suffix("anthropic/sonnet:high"),
+            "anthropic/sonnet"
+        );
+        assert_eq!(
+            strip_thinking_suffix("openrouter/model:exacto"),
+            "openrouter/model:exacto"
+        );
     }
 
     #[test]

--- a/crates/pi-bridge/src/handlers/turn.rs
+++ b/crates/pi-bridge/src/handlers/turn.rs
@@ -55,6 +55,7 @@ use crate::pool::pi_protocol as pi;
 use crate::state::ConnectionState;
 use crate::translate::events::{EventTranslatorState, turn_status_from_agent_end};
 use crate::translate::input::translate_user_input;
+use crate::translate::items::{translate_messages, user_item_id};
 
 /// Per-thread active-turn registry. Pi only allows one active turn per
 /// process, so this is a 1:1 map. Keyed by codex `thread_id`.
@@ -122,6 +123,8 @@ pub async fn handle_turn_start(
     let prompt = translate_user_input(&params.input)
         .map_err(|e| TurnError::InputTranslation(e.to_string()))?;
 
+    let next_turn_index = next_turn_index(&handle).await?;
+
     let turn_id = Uuid::now_v7().to_string();
     let approval_policy = params
         .approval_policy
@@ -167,7 +170,7 @@ pub async fn handle_turn_start(
     // Clients render history from these item events; if we skip the echo,
     // the user's prompt never shows up in `thread/read`.
     let user_message_item = p::ThreadItem::UserMessage {
-        id: Uuid::now_v7().to_string(),
+        id: user_item_id(next_turn_index),
         content: params.input.clone(),
     };
     if state.should_emit("item/started") {
@@ -224,6 +227,7 @@ pub async fn handle_turn_start(
         approval_policy,
         events_rx,
         started_at,
+        turn_index: next_turn_index,
     });
 
     Ok(p::TurnStartResponse { turn })
@@ -390,6 +394,24 @@ fn split_model_selection(model: &str) -> Option<(&str, &str)> {
     (!provider.is_empty() && !model_id.is_empty()).then_some((provider, model_id))
 }
 
+async fn next_turn_index(handle: &Arc<PiProcessHandle>) -> Result<usize, TurnError> {
+    let resp = handle
+        .send_request(pi::RpcCommand::GetMessages(pi::BareCmd::default()))
+        .await
+        .map_err(|e| TurnError::PiRpc(e.to_string()))?;
+    if !resp.success {
+        return Err(TurnError::PiRpc(
+            resp.error.unwrap_or_else(|| "get_messages failed".into()),
+        ));
+    }
+    let data: pi::GetMessagesData = serde_json::from_value(
+        resp.data
+            .ok_or_else(|| TurnError::PiRpc("missing messages data".into()))?,
+    )
+    .map_err(|e| TurnError::PiRpc(format!("decode messages: {e}")))?;
+    Ok(translate_messages(&data.messages).len())
+}
+
 fn notification_frame(notif: p::ServerNotification) -> p::JsonRpcMessage {
     let value = serde_json::to_value(&notif).expect("ServerNotification serializes");
     let method = value
@@ -413,6 +435,7 @@ struct EventPumpArgs {
     approval_policy: p::AskForApproval,
     events_rx: broadcast::Receiver<pi::PiEvent>,
     started_at: i64,
+    turn_index: usize,
 }
 
 fn spawn_event_pump(args: EventPumpArgs) {
@@ -422,7 +445,11 @@ fn spawn_event_pump(args: EventPumpArgs) {
 }
 
 async fn run_event_pump(mut args: EventPumpArgs) {
-    let mut translator = EventTranslatorState::new(args.thread_id.clone(), args.turn_id.clone());
+    let mut translator = EventTranslatorState::with_turn_index(
+        args.thread_id.clone(),
+        args.turn_id.clone(),
+        args.turn_index,
+    );
     let mut error_message: Option<String> = None;
     let mut sent_completed = false;
 

--- a/crates/pi-bridge/src/pool/pi_protocol.rs
+++ b/crates/pi-bridge/src/pool/pi_protocol.rs
@@ -685,6 +685,7 @@ pub enum CompactionReason {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum ExtensionUiRequest {
+    #[serde(alias = "select")]
     Select {
         id: String,
         title: String,
@@ -692,6 +693,7 @@ pub enum ExtensionUiRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout: Option<u64>,
     },
+    #[serde(alias = "confirm")]
     Confirm {
         id: String,
         title: String,
@@ -699,6 +701,7 @@ pub enum ExtensionUiRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout: Option<u64>,
     },
+    #[serde(alias = "input")]
     Input {
         id: String,
         title: String,
@@ -707,12 +710,14 @@ pub enum ExtensionUiRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout: Option<u64>,
     },
+    #[serde(alias = "editor")]
     Editor {
         id: String,
         title: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         prefill: Option<String>,
     },
+    #[serde(alias = "notify")]
     Notify {
         id: String,
         message: String,
@@ -723,6 +728,7 @@ pub enum ExtensionUiRequest {
         )]
         notify_type: Option<NotifyType>,
     },
+    #[serde(alias = "setStatus")]
     SetStatus {
         id: String,
         #[serde(rename = "statusKey")]
@@ -730,6 +736,7 @@ pub enum ExtensionUiRequest {
         #[serde(rename = "statusText")]
         status_text: Option<String>,
     },
+    #[serde(alias = "setWidget")]
     SetWidget {
         id: String,
         #[serde(rename = "widgetKey")]
@@ -743,14 +750,10 @@ pub enum ExtensionUiRequest {
         )]
         widget_placement: Option<WidgetPlacement>,
     },
-    SetTitle {
-        id: String,
-        title: String,
-    },
-    SetEditorText {
-        id: String,
-        text: String,
-    },
+    #[serde(alias = "setTitle")]
+    SetTitle { id: String, title: String },
+    #[serde(alias = "setEditorText")]
+    SetEditorText { id: String, text: String },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -1431,6 +1434,55 @@ mod tests {
             _ => panic!("expected extension_ui_request select"),
         }
         assert_eq!(serde_json::to_value(&event).unwrap(), body);
+    }
+
+    #[test]
+    fn pi_event_extension_ui_request_accepts_camel_case_status_and_widget() {
+        let status = json!({
+            "type":"extension_ui_request",
+            "method":"setStatus",
+            "id":"s1",
+            "statusKey":"speed",
+            "statusText":"idle"
+        });
+        match serde_json::from_value::<PiOutboundMessage>(status).unwrap() {
+            PiOutboundMessage::Event(PiEvent::ExtensionUiRequest(
+                ExtensionUiRequest::SetStatus {
+                    id,
+                    status_key,
+                    status_text,
+                },
+            )) => {
+                assert_eq!(id, "s1");
+                assert_eq!(status_key, "speed");
+                assert_eq!(status_text.as_deref(), Some("idle"));
+            }
+            other => panic!("expected setStatus extension UI request, got {other:?}"),
+        }
+
+        let widget = json!({
+            "type":"extension_ui_request",
+            "method":"setWidget",
+            "id":"w1",
+            "widgetKey":"git-status",
+            "widgetPlacement":"belowEditor"
+        });
+        match serde_json::from_value::<PiOutboundMessage>(widget).unwrap() {
+            PiOutboundMessage::Event(PiEvent::ExtensionUiRequest(
+                ExtensionUiRequest::SetWidget {
+                    id,
+                    widget_key,
+                    widget_lines,
+                    widget_placement,
+                },
+            )) => {
+                assert_eq!(id, "w1");
+                assert_eq!(widget_key, "git-status");
+                assert!(widget_lines.is_none());
+                assert_eq!(widget_placement, Some(WidgetPlacement::BelowEditor));
+            }
+            other => panic!("expected setWidget extension UI request, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/pi-bridge/src/translate/events.rs
+++ b/crates/pi-bridge/src/translate/events.rs
@@ -37,6 +37,7 @@ use crate::pool::pi_protocol::{
     AgentMessage, AssistantContentBlock, AssistantMessage, AssistantMessageEvent, PiEvent,
     StopReason as PiStopReason,
 };
+use crate::translate::items::{assistant_item_id, reasoning_item_id};
 use crate::translate::tool_call::{CodexToolKind, classify};
 
 /// Per-(thread, turn) state the translator carries between events.
@@ -48,6 +49,7 @@ use crate::translate::tool_call::{CodexToolKind, classify};
 pub struct EventTranslatorState {
     thread_id: String,
     turn_id: String,
+    turn_index: usize,
     open_message_item: Option<OpenItem>,
     open_reasoning_item: Option<OpenItem>,
     open_tool_calls: HashMap<String, OpenToolCall>,
@@ -74,9 +76,18 @@ struct OpenToolCall {
 
 impl EventTranslatorState {
     pub fn new(thread_id: impl Into<String>, turn_id: impl Into<String>) -> Self {
+        Self::with_turn_index(thread_id, turn_id, 0)
+    }
+
+    pub fn with_turn_index(
+        thread_id: impl Into<String>,
+        turn_id: impl Into<String>,
+        turn_index: usize,
+    ) -> Self {
         Self {
             thread_id: thread_id.into(),
             turn_id: turn_id.into(),
+            turn_index,
             open_message_item: None,
             open_reasoning_item: None,
             open_tool_calls: HashMap::new(),
@@ -182,7 +193,7 @@ impl EventTranslatorState {
     // ---- message lifecycle -------------------------------------------------
 
     fn translate_message_start(&mut self, message: AssistantMessage) -> Vec<ServerNotification> {
-        let item_id = new_item_id();
+        let item_id = assistant_item_id(self.turn_index, message.timestamp);
         self.open_message_item = Some(OpenItem {
             item_id: item_id.clone(),
         });
@@ -200,7 +211,7 @@ impl EventTranslatorState {
     ) -> Vec<ServerNotification> {
         match event {
             AssistantMessageEvent::TextStart { .. } => Vec::new(),
-            AssistantMessageEvent::TextDelta { delta, .. } => {
+            AssistantMessageEvent::TextDelta { delta, partial, .. } => {
                 if let Some(item) = self.open_message_item.as_ref() {
                     vec![ServerNotification::AgentMessageDelta(
                         AgentMessageDeltaNotification {
@@ -212,7 +223,7 @@ impl EventTranslatorState {
                         },
                     )]
                 } else {
-                    let mut out = self.translate_message_start(AssistantMessage::placeholder());
+                    let mut out = self.translate_message_start(partial);
                     if let Some(item) = self.open_message_item.as_ref() {
                         out.push(ServerNotification::AgentMessageDelta(
                             AgentMessageDeltaNotification {
@@ -229,8 +240,8 @@ impl EventTranslatorState {
             }
             AssistantMessageEvent::TextEnd { .. } => Vec::new(),
 
-            AssistantMessageEvent::ThinkingStart { .. } => {
-                let item_id = new_item_id();
+            AssistantMessageEvent::ThinkingStart { partial, .. } => {
+                let item_id = reasoning_item_id(self.turn_index, partial.timestamp);
                 self.open_reasoning_item = Some(OpenItem {
                     item_id: item_id.clone(),
                 });
@@ -956,36 +967,6 @@ fn mcp_result_split(
     (Some(Box::new(payload)), None)
 }
 
-impl AssistantMessage {
-    fn placeholder() -> Self {
-        Self {
-            role: crate::pool::pi_protocol::AssistantRole::Assistant,
-            content: Vec::new(),
-            api: String::new(),
-            provider: String::new(),
-            model: String::new(),
-            response_id: None,
-            usage: crate::pool::pi_protocol::Usage {
-                input: 0,
-                output: 0,
-                cache_read: 0,
-                cache_write: 0,
-                total_tokens: 0,
-                cost: crate::pool::pi_protocol::UsageCost {
-                    input: 0.0,
-                    output: 0.0,
-                    cache_read: 0.0,
-                    cache_write: 0.0,
-                    total: 0.0,
-                },
-            },
-            stop_reason: PiStopReason::Stop,
-            error_message: None,
-            timestamp: 0,
-        }
-    }
-}
-
 /// Helper for `handlers/turn.rs`: derive a `TurnStatus`/`TurnError` pair from
 /// the optional error string carried out of the final pi event of a turn.
 pub fn turn_status_from_agent_end(error_message: Option<&str>) -> (TurnStatus, Option<TurnError>) {
@@ -1012,11 +993,18 @@ mod tests {
     };
 
     fn state() -> EventTranslatorState {
-        EventTranslatorState::new("th_1", "tu_1")
+        EventTranslatorState::with_turn_index("th_1", "tu_1", 7)
     }
 
     fn agent_msg(text: &str) -> AgentMessage {
         AgentMessage::Assistant(assistant_message(text))
+    }
+
+    fn item_id_from_started(notification: &ServerNotification) -> &str {
+        match notification {
+            ServerNotification::ItemStarted(n) => n.item.id(),
+            other => panic!("expected ItemStarted, got {other:?}"),
+        }
     }
 
     fn assistant_message(text: &str) -> AssistantMessage {
@@ -1067,7 +1055,7 @@ mod tests {
         match &out[0] {
             ServerNotification::ItemStarted(n) => match &n.item {
                 ThreadItem::AgentMessage { id, text, .. } => {
-                    assert!(!id.is_empty());
+                    assert_eq!(id, "assistant_7_0");
                     assert_eq!(text, "");
                 }
                 other => panic!("expected AgentMessage, got {other:?}"),
@@ -1106,6 +1094,58 @@ mod tests {
     }
 
     #[test]
+    fn live_stream_item_ids_match_replay_ids_for_same_turn_index() {
+        let mut live = EventTranslatorState::with_turn_index("th_1", "live_turn", 3);
+        let mut message = assistant_message("answer");
+        message.content.insert(
+            0,
+            AssistantContentBlock::Thinking(crate::pool::pi_protocol::ThinkingContent {
+                thinking: "ponder".into(),
+                thinking_signature: None,
+                redacted: None,
+            }),
+        );
+        message.timestamp = 42;
+
+        let started = live.translate(PiEvent::MessageStart {
+            message: AgentMessage::Assistant(message.clone()),
+        });
+        let thinking = live.translate(PiEvent::MessageUpdate {
+            message: AgentMessage::Assistant(message.clone()),
+            assistant_message_event: AssistantMessageEvent::ThinkingStart {
+                content_index: 0,
+                partial: message.clone(),
+            },
+        });
+
+        let replay = crate::translate::items::translate_messages(&[
+            AgentMessage::User(crate::pool::pi_protocol::UserMessage {
+                role: crate::pool::pi_protocol::UserRole::User,
+                content: crate::pool::pi_protocol::UserMessageContent::Text("q".into()),
+                timestamp: 1,
+            }),
+            AgentMessage::User(crate::pool::pi_protocol::UserMessage {
+                role: crate::pool::pi_protocol::UserRole::User,
+                content: crate::pool::pi_protocol::UserMessageContent::Text("q".into()),
+                timestamp: 2,
+            }),
+            AgentMessage::User(crate::pool::pi_protocol::UserMessage {
+                role: crate::pool::pi_protocol::UserRole::User,
+                content: crate::pool::pi_protocol::UserMessageContent::Text("q".into()),
+                timestamp: 3,
+            }),
+            AgentMessage::User(crate::pool::pi_protocol::UserMessage {
+                role: crate::pool::pi_protocol::UserRole::User,
+                content: crate::pool::pi_protocol::UserMessageContent::Text("q".into()),
+                timestamp: 4,
+            }),
+            AgentMessage::Assistant(message),
+        ]);
+        assert_eq!(item_id_from_started(&started[0]), replay[3].items[1].id());
+        assert_eq!(item_id_from_started(&thinking[0]), replay[3].items[2].id());
+    }
+
+    #[test]
     fn thinking_lifecycle_emits_reasoning_item() {
         let mut s = state();
         let started = s.translate(PiEvent::MessageUpdate {
@@ -1116,7 +1156,13 @@ mod tests {
             },
         });
         assert_eq!(started.len(), 1);
-        assert!(matches!(started[0], ServerNotification::ItemStarted(_)));
+        match &started[0] {
+            ServerNotification::ItemStarted(n) => match &n.item {
+                ThreadItem::Reasoning { id, .. } => assert_eq!(id, "reasoning_7_0"),
+                other => panic!("expected Reasoning, got {other:?}"),
+            },
+            other => panic!("unexpected {other:?}"),
+        }
 
         let delta = s.translate(PiEvent::MessageUpdate {
             message: agent_msg(""),

--- a/crates/pi-bridge/src/translate/items.rs
+++ b/crates/pi-bridge/src/translate/items.rs
@@ -60,7 +60,8 @@ pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
                     current_started_at = Some(asst.timestamp);
                 }
                 current_completed_at = Some(asst.timestamp);
-                push_assistant_items(asst, &mut current_items, &tool_results);
+                let turn_index = turns.len();
+                push_assistant_items(asst, turn_index, &mut current_items, &tool_results);
             }
             AgentMessage::ToolResult(_) => {
                 // Folded into the matching tool-call item via `tool_results`.
@@ -117,6 +118,18 @@ fn index_tool_results<'a>(messages: &'a [AgentMessage]) -> HashMap<&'a str, &'a 
     out
 }
 
+pub(crate) fn user_item_id(turn_index: usize) -> String {
+    format!("user_{turn_index}")
+}
+
+pub(crate) fn assistant_item_id(turn_index: usize, timestamp: i64) -> String {
+    format!("assistant_{turn_index}_{timestamp}")
+}
+
+pub(crate) fn reasoning_item_id(turn_index: usize, timestamp: i64) -> String {
+    format!("reasoning_{turn_index}_{timestamp}")
+}
+
 fn user_message_to_item(message: &UserMessage, turn_index: usize) -> ThreadItem {
     let content = match &message.content {
         UserMessageContent::Text(s) => vec![UserInput::Text {
@@ -137,13 +150,14 @@ fn user_message_to_item(message: &UserMessage, turn_index: usize) -> ThreadItem 
             .collect(),
     };
     ThreadItem::UserMessage {
-        id: format!("user_{turn_index}_{}", message.timestamp),
+        id: user_item_id(turn_index),
         content,
     }
 }
 
 fn push_assistant_items(
     message: &AssistantMessage,
+    turn_index: usize,
     out: &mut Vec<ThreadItem>,
     tool_results: &HashMap<&str, &ToolResultMessage>,
 ) {
@@ -160,7 +174,7 @@ fn push_assistant_items(
 
     if !text.is_empty() {
         out.push(ThreadItem::AgentMessage {
-            id: format!("assistant_{}", message.timestamp),
+            id: assistant_item_id(turn_index, message.timestamp),
             text,
             phase: Some(serde_json::Value::String("final_answer".into())),
             memory_citation: None,
@@ -168,7 +182,7 @@ fn push_assistant_items(
     }
     if !thinking.is_empty() {
         out.push(ThreadItem::Reasoning {
-            id: format!("reasoning_{}", message.timestamp),
+            id: reasoning_item_id(turn_index, message.timestamp),
             summary: Vec::new(),
             content: thinking,
         });
@@ -501,7 +515,8 @@ mod tests {
         assert_eq!(turns.len(), 1);
         assert_eq!(turns[0].items.len(), 1);
         match &turns[0].items[0] {
-            ThreadItem::UserMessage { content, .. } => {
+            ThreadItem::UserMessage { id, content } => {
+                assert_eq!(id, "user_0");
                 assert_eq!(content.len(), 1);
                 match &content[0] {
                     UserInput::Text { text, .. } => assert_eq!(text, "hello"),
@@ -573,6 +588,9 @@ mod tests {
             })
             .collect();
         assert_eq!(kinds, vec!["user", "agent", "reasoning"]);
+        assert_eq!(turns[0].items[0].id(), "user_0");
+        assert_eq!(turns[0].items[1].id(), "assistant_0_2");
+        assert_eq!(turns[0].items[2].id(), "reasoning_0_2");
     }
 
     #[test]


### PR DESCRIPTION
Summary

* add runtime capability flags for thread permission overrides/effective permission reporting
* accept Pi camelCase extension_ui_request methods
* filter Pi model/list by enabledModels from Pi settings
* add probe resume flags to exercise Fresh -> Resumed reconnect/replay paths

## Validation

* cargo test -p alleycat-pi-bridge model -- --nocapture
* Litter SSH bridge probe against normal git dependency: Pi model/list filters 383 -> 15
* Litter live SSH reconnect probe: final thread/turns/list item IDs match local store with zero duplicates