### PR TITLE
feat(host): honor the host.toml relay override for the daemon endpoint

### DIFF
--- a/crates/alleycat/src/daemon/mod.rs
+++ b/crates/alleycat/src/daemon/mod.rs
@@ -64,7 +64,8 @@ pub async fn run() -> anyhow::Result<()> {
     let node_id = secret_key.public().to_string();
     info!(node_id = %node_id, "loaded persistent identity");
 
-    let endpoint = host::bind_endpoint(secret_key.clone()).await?;
+    let relay = config.load().relay.clone();
+    let endpoint = host::bind_endpoint(secret_key.clone(), relay.as_deref()).await?;
     let agents = AgentManager::new(Arc::clone(&config))
         .await
         .context("initializing agent manager")?;

--- a/crates/alleycat/src/host.rs
+++ b/crates/alleycat/src/host.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, anyhow};
 use arc_swap::ArcSwap;
 use iroh::endpoint::QuicTransportConfig;
 use iroh::endpoint::{IdleTimeout, presets};
-use iroh::{Endpoint, SecretKey};
+use iroh::{Endpoint, RelayMap, RelayMode, SecretKey};
 use tokio::sync::Notify;
 use tracing::{info, warn};
 
@@ -18,7 +18,15 @@ use crate::stream::IrohStream;
 /// Bind the iroh endpoint with the given identity and ALPN, returning it
 /// ready to be passed to [`accept_loop`]. Spawns a background "online" probe
 /// that logs when the endpoint reports relay connectivity.
-pub async fn bind_endpoint(secret_key: SecretKey) -> anyhow::Result<Endpoint> {
+///
+/// When `relay` is `Some`, the endpoint is pinned to that single relay
+/// (`RelayMode::Custom`) instead of the default number0 relays. This lets an
+/// operator point the daemon at a closer / self-hosted relay via the `relay`
+/// field in `host.toml`.
+pub async fn bind_endpoint(
+    secret_key: SecretKey,
+    relay: Option<&str>,
+) -> anyhow::Result<Endpoint> {
     // iroh defaults already PING every 5s (HEARTBEAT_INTERVAL) which would
     // normally keep the connection alive — but the connection-wide
     // `max_idle_timeout` is still 30s by default, and once the holepunched
@@ -34,10 +42,23 @@ pub async fn bind_endpoint(secret_key: SecretKey) -> anyhow::Result<Endpoint> {
         .max_idle_timeout(Some(idle_timeout))
         .build();
 
-    let endpoint = Endpoint::builder(presets::N0)
+    let mut builder = Endpoint::builder(presets::N0)
         .secret_key(secret_key)
         .alpns(vec![ALLEYCAT_ALPN.to_vec()])
-        .transport_config(transport)
+        .transport_config(transport);
+
+    // Honor a relay pinned in host.toml (`relay = "https://..."`). Without an
+    // explicit override, presets::N0 always uses the number0 relays, which may
+    // be geographically distant and add latency on relayed paths; pinning a
+    // closer self-hosted relay lets operators cut that latency.
+    if let Some(relay_url) = relay {
+        let relay_map = RelayMap::try_from_iter([relay_url])
+            .with_context(|| format!("parsing configured relay URL {relay_url:?}"))?;
+        builder = builder.relay_mode(RelayMode::Custom(relay_map));
+        info!(relay = %relay_url, "using custom relay from host.toml");
+    }
+
+    let endpoint = builder
         .bind()
         .await
         .context("binding iroh endpoint")?;


### PR DESCRIPTION
## Problem

The `relay` field in `host.toml` (`HostConfig.relay`) is currently never wired into the iroh endpoint. `bind_endpoint` always builds the endpoint with `presets::N0`, so the daemon unconditionally uses the default number0 relays. The configured `relay` value is only used as a display fallback in the pair payload (`endpoint_home_relay(...).or_else(|| cfg.relay)`), which makes the setting look effective while routing still goes through n0 relays.

## Change

- `host::bind_endpoint` now takes `relay: Option<&str>`.
- When a relay is configured, the endpoint is built with `RelayMode::Custom(RelayMap::try_from_iter([relay_url])?)`, pinning the daemon to that relay (e.g. a self-hosted, geographically closer one).
- When `relay` is unset, behavior is unchanged: the builder keeps `presets::N0` exactly as before.
- `daemon::run` passes `config.load().relay.as_deref()` into `bind_endpoint`.

## Notes

- Changing the `relay` value requires restarting the daemon — it is read once at endpoint bind time, so `reload` alone won't re-bind to the new relay.
- Node discovery (pkarr/DNS publishing) still uses the N0 preset by design; only relay traffic moves to the custom relay, so clients can still discover the host.
- `probe.rs` (the `alleycat probe` test client) intentionally remains on `presets::N0` and is out of scope for this PR — it dials the peer's published home relay directly and doesn't need the custom relay in its own map.

## Testing

- `cargo check` passes on the workspace.
- Built the daemon with a self-hosted iroh-relay configured via `relay = "https://relay.47lab.cn"` in `host.toml`: `status` reports the custom relay as home relay and the endpoint comes online via `Relay(https://relay.47lab.cn/)`; with the field unset, it still connects through the default n0 relays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)