### PR TITLE
codex: fall back to unix proxy when daemon lifecycle fails

### DIFF
--- a/crates/alleycat/src/agents.rs
+++ b/crates/alleycat/src/agents.rs
@@ -531,7 +531,19 @@ impl AgentManager {
 
     async fn serve_codex_unix_proxy(&self, mut iroh_stream: IrohStream) -> anyhow::Result<()> {
         let endpoint = if self.codex_mode == CodexMode::UnixDaemon {
-            self.ensure_codex_daemon_running().await?
+            match self.ensure_codex_daemon_running().await {
+                Ok(endpoint) => endpoint,
+                Err(daemon_error) => {
+                    warn!(
+                        "codex app-server daemon lifecycle failed; falling back to unix listen/proxy mode: {daemon_error:#}"
+                    );
+                    self.ensure_codex_unix_running().await.with_context(|| {
+                        format!(
+                            "codex app-server daemon lifecycle failed and unix listen/proxy fallback also failed: {daemon_error:#}"
+                        )
+                    })?
+                }
+            }
         } else {
             self.ensure_codex_unix_running().await?
         };


### PR DESCRIPTION
## Purpose

On some machines (an enterprise/work setup, in this case) codex gets classified as `UnixDaemon` because `codex app-server daemon --help` succeeds, but the actual daemon lifecycle (`app-server daemon start` plus the socket probe) fails at runtime. Sandboxing, socket-dir perms, no detach, that kind of thing. When that happens, `serve_codex_unix_proxy` errors the stream out and the client can't connect.

It showed up as litter not being able to connect at all. Falling back to the per-stream unix proxy path fixed it.

## Key changes

- `crates/alleycat/src/agents.rs`: in `serve_codex_unix_proxy`, when we're in `UnixDaemon` mode and `ensure_codex_daemon_running()` fails, fall back to `ensure_codex_unix_running()` instead of erroring out. That's the per-stream `app-server proxy` path, which doesn't need the daemon lifecycle. If the fallback fails too, both errors end up in the context.

Scope is one function, +13/-1. No style or dependency changes.

## Verification

- `cargo build -p alleycat` builds clean (only the pre-existing dead-code warnings).
- On the affected machine, litter connects after the change.

## Possible follow-up (not in this PR)

The fallback runs per stream, so if the daemon is *persistently* broken, every new connection retries the dead `daemon start` before falling back. Cheap when `daemon start` fails fast, but it could stall a connection for up to ~90s if `daemon start` ever hangs. A sticky downgrade (flip `codex_mode` to `UnixProxy` for the rest of the process after the first failure) would skip the repeated retry, but it'd mean making `codex_mode` mutable (atomic or a lock). I left it out to keep this small. Happy to do it as a separate PR if you want.
