### PR TITLE
codex: avoid daemon mode without standalone install

### DIFF
--- a/crates/alleycat/src/agents.rs
+++ b/crates/alleycat/src/agents.rs
@@ -1222,6 +1222,10 @@ async fn codex_app_server_proxy_supported(bin: &Path, env: &LaunchEnvironment) -
 }
 
 async fn codex_app_server_daemon_supported(bin: &Path, env: &LaunchEnvironment) -> bool {
+    if !codex_managed_standalone_available(env) {
+        return false;
+    }
+
     let mut command = codex_command(bin);
     apply_launch_env_to_command(&mut command, env);
     command
@@ -1234,6 +1238,27 @@ async fn codex_app_server_daemon_supported(bin: &Path, env: &LaunchEnvironment) 
         tokio::time::timeout(Duration::from_secs(5), command.status()).await,
         Ok(Ok(status)) if status.success()
     )
+}
+
+fn codex_managed_standalone_available(env: &LaunchEnvironment) -> bool {
+    #[cfg(windows)]
+    let names: &[&str] = &["codex.exe", "codex.cmd", "codex.bat", "codex.com"];
+    #[cfg(not(windows))]
+    let names: &[&str] = &["codex"];
+
+    names
+        .iter()
+        .map(|name| codex_managed_standalone_path(env).join(name))
+        .any(|path| is_executable_file(&path))
+}
+
+fn codex_managed_standalone_path(env: &LaunchEnvironment) -> PathBuf {
+    env_path(env, "CODEX_HOME")
+        .or_else(|| env_path(env, "HOME").map(|home| home.join(".codex")))
+        .unwrap_or_else(|| PathBuf::from(".codex"))
+        .join("packages")
+        .join("standalone")
+        .join("current")
 }
 
 #[derive(Debug, Deserialize)]
@@ -1581,6 +1606,42 @@ mod tests {
 
         assert!(program_available(&env, "agent"));
         assert_eq!(resolve_pi_bin("pi", &env), None);
+    }
+
+    #[test]
+    fn codex_daemon_requires_managed_standalone_install() {
+        let mut home = crate::test_support::TempHome::new();
+        home.override_env(&[("CODEX_HOME", "")]);
+        let env = LaunchEnvironment::current();
+
+        assert!(!codex_managed_standalone_available(&env));
+    }
+
+    #[test]
+    fn codex_daemon_accepts_codex_home_standalone_install() {
+        let mut home = crate::test_support::TempHome::new();
+        let codex_home = home.path().join("custom-codex-home");
+        let standalone_dir = codex_home.join("packages/standalone/current");
+        std::fs::create_dir_all(&standalone_dir).unwrap();
+        #[cfg(windows)]
+        let codex = standalone_dir.join("codex.exe");
+        #[cfg(not(windows))]
+        let codex = standalone_dir.join("codex");
+        std::fs::write(&codex, b"#!/bin/sh\n").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&codex).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&codex, perms).unwrap();
+        }
+
+        home.override_env(&[("CODEX_HOME", codex_home.to_str().unwrap())]);
+        let env = LaunchEnvironment::current();
+
+        assert_eq!(codex_managed_standalone_path(&env), standalone_dir);
+        assert!(codex_managed_standalone_available(&env));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require a managed Codex standalone install before selecting UnixDaemon mode
- fall back to UnixProxy for Homebrew/Cask Codex installs that expose `app-server daemon --help` but cannot run `app-server daemon start`
- add tests for missing and CODEX_HOME-managed standalone installs

## Why
KittyLitter/Litter can currently mark Codex as available, then fail on first connect when Codex was installed through Homebrew/Cask:

```text
Error: managed standalone Codex install not found at ~/.codex/packages/standalone/current/codex
```

The CLI advertises the daemon subcommand, but daemon startup requires the installer-managed standalone path. Treating `daemon --help` as sufficient selects `UnixDaemon` and prevents the existing Unix proxy fallback from being used.

## Verification
- `cargo fmt -p alleycat --check`
- `cargo test -p alleycat codex_daemon -- --nocapture`
- `cargo test -p alleycat`

Note: full workspace formatting currently reports pre-existing formatting diffs in `crates/grok-bridge/src/lib.rs`; not touched by this PR.