### PR TITLE
fix(shell-bridge): drop stale shell session on reattach

### DIFF
--- a/crates/bridge-core/src/session/registry.rs
+++ b/crates/bridge-core/src/session/registry.rs
@@ -120,6 +120,15 @@ impl SessionRegistry {
         agent: AgentId,
         last_seen: Option<u64>,
     ) -> ResolvedAttach {
+        // ponytail: the shell agent's ring holds shell/output+shell/exit
+        // notifications from a killed pty. Replaying them to a reattaching
+        // client makes the client treat a stale exit as its own and drop
+        // the terminal (see litter remote_alleycat read_output_loop). Shell
+        // has no meaningful cross-connection state, so drop any prior
+        // session on reattach and always start Fresh.
+        if agent == "shell" {
+            self.inner.lock().unwrap().remove(&(node_id.clone(), agent));
+        }
         let (session, was_existing) = {
             let mut inner = self.inner.lock().unwrap();
             let key = (node_id.clone(), agent);


### PR DESCRIPTION
## Summary
- On every reattach the shell agent's ring was replayed to the reconnecting client, delivering `shell/output` and `shell/exit` notifications from prior killed pty sessions.
- Litter's Android/iOS terminal read loop accepts these stale frames as its own (because its expected `session_id` is still `None` before `shell/spawn` returns) and breaks on the stale `shell/exit`, producing `v1-Backend: terminal JSON-RPC stream closed` on every reconnect.
- Shell has no meaningful cross-connection state, so drop any prior `(node_id, shell)` session at `resolve_attach` time and always start Fresh.

## Verification
Reproduced against a live kittylitter 0.3.4 running from `~/.npm/_npx/.../kittylitter/node_modules/.bin_real/kittylitter`. Before the patch every non-first attach logged \`attached=Resumed current_seq=N\` and closed with \`closed by peer: 0\` within ~10 ms. After swapping in a locally-built kittylitter with this patch every attach logs \`attached=Fresh current_seq=0\` and the Android terminal stays up across background/foreground cycles.

## Test plan
- [x] Manual: Android app terminal open/close/reopen loop against local daemon
- [x] Existing \`session::registry\` unit tests still pass (Fresh/Resumed/DriftReload cases unaffected for non-shell agents)