### PR TITLE
Fix Windows PATH lookup case sensitivity

### DIFF
--- a/crates/bridge-core/src/launch_environment.rs
+++ b/crates/bridge-core/src/launch_environment.rs
@@ -485,7 +485,10 @@ fn find_provider_on_path(program: &str, env: &EnvMap, fallback_paths: &[&str]) -
 }
 
 fn find_on_path(program: &str, env: &EnvMap) -> Option<PathBuf> {
-    let path = env.get(OsStr::new("PATH"))?;
+    // Windows stores the variable as `Path`, so an exact `PATH` lookup misses it.
+    let path = ["PATH", "Path"]
+        .iter()
+        .find_map(|k| env.get(OsStr::new(k)))?;
     for dir in std::env::split_paths(path) {
         let candidate = dir.join(program);
         if is_executable_file(&candidate) {
@@ -608,6 +611,35 @@ mod tests {
         let path = std::env::join_paths([first.as_path(), second.as_path()]).expect("join path");
         let mut env = EnvMap::new();
         env.insert(OsString::from("PATH"), path);
+
+        assert_eq!(
+            find_on_path("agent", &env).as_deref(),
+            Some(executable.as_path())
+        );
+    }
+
+    #[test]
+    fn find_on_path_accepts_windows_path_key_casing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let executable = temp
+            .path()
+            .join(if cfg!(windows) { "agent.exe" } else { "agent" });
+        std::fs::write(&executable, "#!/bin/sh\n").expect("write executable");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&executable)
+                .expect("executable metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&executable, perms).expect("chmod executable");
+        }
+
+        let mut env = EnvMap::new();
+        env.insert(
+            OsString::from("Path"),
+            temp.path().as_os_str().to_os_string(),
+        );
 
         assert_eq!(
             find_on_path("agent", &env).as_deref(),


### PR DESCRIPTION
windows connection doesnt show claude or devin otherwise (surprisingly, it shows codex)