### PR TITLE
local-studio: stop implying grant enforcement, and test the runtime that ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev libcap-dev clang cmake
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # Everything must compile, including tests and benches. This alone would
+      # have caught more than the repo had before, since there was no CI at all.
+      - name: Build
+        run: cargo build --workspace --all-targets
+
+      # This repo has never had CI, so several suites are already red. Rather
+      # than a skip list that silently grows, the exclusions are whole crates
+      # plus one named test, each with a reason. New crates are covered
+      # automatically. Verified against a clean checkout of the branch point —
+      # none of these are caused by the change this workflow ships with.
+      #
+      #   alleycat-bridge-conformance  live harness: launches real agent
+      #                                binaries and diffs their wire output;
+      #                                most cases are already #[ignore]d and
+      #                                `conformance_acp` needs an ACP agent
+      #                                installed. Stays a local/manual suite.
+      #   alleycat-acp-bridge          test_acp_to_codex_initialize_result fails
+      #   alleycat-opencode-bridge     5 failures across v2_cross_cwd,
+      #                                v3_resume, v7_tool_call_surfacing
+      #   posix_resolver_accepts_dev_suffix_versions  (alleycat-bridge-core)
+      #                                fails; the crate's other 55 tests gate
+      #
+      # Tracked in #33. Remove each exclusion as it is fixed.
+      - name: Test
+        run: |
+          cargo test --workspace \
+            --exclude alleycat-bridge-conformance \
+            --exclude alleycat-acp-bridge \
+            --exclude alleycat-opencode-bridge \
+            -- --skip posix_resolver_accepts_dev_suffix_versions
+
+      # Advisory until the existing warnings are cleared — `crates/alleycat`
+      # alone emits 37 dead-code warnings from the unreachable Local Studio
+      # gateway (see #31).
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,12 @@ jobs:
             --exclude alleycat-opencode-bridge \
             -- --skip posix_resolver_accepts_dev_suffix_versions
 
-      # Advisory until the existing warnings are cleared — `crates/alleycat`
-      # alone emits 37 dead-code warnings from the unreachable Local Studio
-      # gateway (see #31).
-      - name: Clippy
+      # Advisory until the existing lints are cleared: `crates/alleycat` emits
+      # 37 dead-code warnings from the unreachable Local Studio gateway (#31),
+      # and `alleycat-bridge-core` has 3 real clippy findings. `continue-on-error`
+      # reports this step as "success" even when it fails, so the name says
+      # non-blocking — otherwise a green tick here reads as a clean lint run.
+      # Drop `continue-on-error` once #31 and #33 land.
+      - name: Clippy (advisory, non-blocking)
         run: cargo clippy --workspace --all-targets -- -D warnings
         continue-on-error: true

--- a/crates/alleycat/src/agents.rs
+++ b/crates/alleycat/src/agents.rs
@@ -1731,6 +1731,179 @@ fn has_amp_auth(api_key_env: &str, env: &LaunchEnvironment) -> bool {
 }
 
 #[cfg(test)]
+mod local_studio_launcher_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Captures the spec it is handed and fails the launch. The decorator's
+    /// contract is the spec rewrite, not the spawn.
+    struct CapturingLauncher {
+        captured: Mutex<Option<alleycat_bridge_core::ProcessSpec>>,
+    }
+
+    impl CapturingLauncher {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                captured: Mutex::new(None),
+            })
+        }
+
+        fn take(&self) -> alleycat_bridge_core::ProcessSpec {
+            self.captured
+                .lock()
+                .expect("capture mutex poisoned")
+                .take()
+                .expect("launcher was never invoked")
+        }
+    }
+
+    impl ProcessLauncher for CapturingLauncher {
+        fn launch(
+            &self,
+            spec: alleycat_bridge_core::ProcessSpec,
+        ) -> futures::future::BoxFuture<
+            '_,
+            std::io::Result<Box<dyn alleycat_bridge_core::ChildProcess>>,
+        > {
+            *self.captured.lock().expect("capture mutex poisoned") = Some(spec);
+            Box::pin(async {
+                Err(std::io::Error::other("capturing launcher does not spawn"))
+            })
+        }
+    }
+
+    fn electron_command() -> local_studio::PiRuntimeCommand {
+        local_studio::PiRuntimeCommand {
+            program: PathBuf::from("/Applications/Local Studio.app/Contents/MacOS/Local Studio"),
+            prefix_args: vec![OsString::from(
+                "/Applications/Local Studio.app/Contents/Resources/cli.js",
+            )],
+            env: vec![(
+                OsString::from("ELECTRON_RUN_AS_NODE"),
+                OsString::from("1"),
+            )],
+        }
+    }
+
+    fn env_value<'a>(
+        spec: &'a alleycat_bridge_core::ProcessSpec,
+        key: &str,
+    ) -> Option<&'a std::ffi::OsStr> {
+        spec.env
+            .iter()
+            .find(|(candidate, _)| candidate == key)
+            .map(|(_, value)| value.as_os_str())
+    }
+
+    async fn launch_capturing(
+        spec: alleycat_bridge_core::ProcessSpec,
+    ) -> alleycat_bridge_core::ProcessSpec {
+        let inner = CapturingLauncher::new();
+        let decorated = LocalStudioLauncher::new(
+            Arc::clone(&inner) as Arc<dyn ProcessLauncher>,
+            PathBuf::from("/Users/test/Library/Application Support/Local Studio/pi-agent"),
+            electron_command(),
+        );
+        let _ = decorated.launch(spec).await;
+        inner.take()
+    }
+
+    #[tokio::test]
+    async fn agent_launch_uses_the_bundled_local_studio_runtime() {
+        let mut spec = alleycat_bridge_core::ProcessSpec::new("/usr/bin/pi");
+        spec.role = alleycat_bridge_core::ProcessRole::Agent;
+        spec.args = vec![OsString::from("--mode"), OsString::from("rpc")];
+
+        let launched = launch_capturing(spec).await;
+
+        assert_eq!(
+            launched.program,
+            PathBuf::from("/Applications/Local Studio.app/Contents/MacOS/Local Studio")
+        );
+        assert_eq!(
+            launched
+                .args
+                .iter()
+                .filter_map(|arg| arg.to_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "/Applications/Local Studio.app/Contents/Resources/cli.js",
+                "--mode",
+                "rpc"
+            ],
+            "the bundled CLI must precede the original args, not replace them"
+        );
+        assert_eq!(
+            env_value(&launched, "ELECTRON_RUN_AS_NODE"),
+            Some(std::ffi::OsStr::new("1"))
+        );
+        assert_eq!(
+            env_value(&launched, "PI_CODING_AGENT_DIR"),
+            Some(std::ffi::OsStr::new(
+                "/Users/test/Library/Application Support/Local Studio/pi-agent"
+            )),
+            "Local Studio's Pi home is what keeps this runtime distinct from `pi`"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_commands_keep_their_program_but_still_see_the_agent_dir() {
+        let mut spec = alleycat_bridge_core::ProcessSpec::new("/bin/sh");
+        spec.role = alleycat_bridge_core::ProcessRole::ToolCommand;
+        spec.args = vec![OsString::from("-c"), OsString::from("pwd")];
+
+        let launched = launch_capturing(spec).await;
+
+        assert_eq!(launched.program, PathBuf::from("/bin/sh"));
+        assert_eq!(
+            launched
+                .args
+                .iter()
+                .filter_map(|arg| arg.to_str())
+                .collect::<Vec<_>>(),
+            vec!["-c", "pwd"],
+            "tool commands must not gain the agent CLI prefix"
+        );
+        assert_eq!(
+            env_value(&launched, "PI_CODING_AGENT_DIR"),
+            Some(std::ffi::OsStr::new(
+                "/Users/test/Library/Application Support/Local Studio/pi-agent"
+            ))
+        );
+        assert!(
+            env_value(&launched, "ELECTRON_RUN_AS_NODE").is_none(),
+            "ELECTRON_RUN_AS_NODE is an agent-only concern"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_explicit_agent_dir_is_never_overridden() {
+        let mut spec = alleycat_bridge_core::ProcessSpec::new("/usr/bin/pi");
+        spec.role = alleycat_bridge_core::ProcessRole::Agent;
+        spec.env.push((
+            OsString::from("PI_CODING_AGENT_DIR"),
+            OsString::from("/explicit/override"),
+        ));
+
+        let launched = launch_capturing(spec).await;
+
+        assert_eq!(
+            env_value(&launched, "PI_CODING_AGENT_DIR"),
+            Some(std::ffi::OsStr::new("/explicit/override"))
+        );
+        assert_eq!(
+            launched
+                .env
+                .iter()
+                .filter(|(key, _)| key == "PI_CODING_AGENT_DIR")
+                .count(),
+            1,
+            "the decorator must not append a duplicate agent-dir entry"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/alleycat/src/cli/local_studio.rs
+++ b/crates/alleycat/src/cli/local_studio.rs
@@ -35,6 +35,21 @@ pub enum LocalStudioCommand {
     },
 }
 
+/// Printed by every `local-studio` subcommand.
+///
+/// `f443a83` replaced the signed `LocalStudioBridge` with a second `PiBridge`,
+/// and the new dispatch arm in `agents.rs` discards `authenticated_node`. The
+/// grant store is still written and read faithfully, but nothing consults it
+/// for authorization — `local_studio_agent_info`, the only reader of
+/// `GrantStore::effective`, is dead code. Until that is resolved these
+/// subcommands must not imply an access-control decision they do not make.
+/// See https://github.com/0xSero/alleycat/issues/31.
+const NOT_ENFORCED_NOTICE: &str = "\
+warning: Local Studio grants are NOT currently enforced.
+         The `local-studio` runtime is gated only by the host pair token, so
+         any paired device can reach it regardless of the grants below, and
+         `revoke` does not cut off access. See alleycat issue #31.";
+
 pub async fn run(args: LocalStudioArgs) -> anyhow::Result<()> {
     cli::ensure_current_daemon().await?;
     let request = match args.command {
@@ -74,6 +89,7 @@ pub async fn run(args: LocalStudioArgs) -> anyhow::Result<()> {
         }
     };
     let document: PairedNodesDocument = cli::decode_data(cli::send(request).await?)?;
+    eprintln!("{NOT_ENFORCED_NOTICE}");
     if document.nodes.is_empty() {
         println!("no Local Studio paired-node grants");
         return Ok(());

--- a/crates/alleycat/src/local_studio.rs
+++ b/crates/alleycat/src/local_studio.rs
@@ -69,6 +69,11 @@ struct GatewayMetadata {
     url: Url,
     secret: HeaderValue,
     controller_id: String,
+    /// Local Studio's agent-runtime pid. Only the Linux runtime resolver reads
+    /// it, via `/proc/<pid>/{exe,cwd}`; macOS resolves through the `.app`
+    /// bundle and never touches this.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pid: u32,
     issued_at: String,
 }
 
@@ -415,6 +420,7 @@ fn validate_gateway_metadata(parsed: GatewayMetadataFile) -> anyhow::Result<Gate
         url,
         secret,
         controller_id: parsed.controller_id,
+        pid: parsed.pid,
         issued_at: parsed.issued_at,
     })
 }


### PR DESCRIPTION
Stacked on `codex/litter-local-bridge`. Found while auditing the Local Studio integration end to end from the mobile client (`0xSero/litter#186`) down through this repo into `sybil-solutions/local-studio`.

**+266 / −0 across 4 files.** No behavior change to the shipping runtime.

Grew from 2 files to 4 because adding CI (§3) found that the crate does not build on Linux (§4).

## 1. `kittylitter local-studio revoke` silently no-ops

Full write-up in #31. Short version:

`f443a83` replaced the signed `LocalStudioBridge` with a second `PiBridge`. The new dispatch arm discards the caller identity outright — `crates/alleycat/src/agents.rs`:

```rust
"local-studio" => {
    let _ = authenticated_node;
    let bridge = self.local_studio_bridge.clone()
        .ok_or_else(|| anyhow!("Local Studio runtime is unavailable"))?;
```

and availability became membership-free:

```rust
pub fn local_studio_gateway_available(&self) -> bool {
    self.local_studio_bridge.is_some()
}
```

`cargo check -p alleycat` confirms the capability layer is unreachable:

```
local_studio.rs:93:15:  warning: function `local_studio_agent_info` is never used
local_studio.rs:144:4:  warning: function `authorized_gateway` is never used
local_studio.rs:42:7:   warning: constant `IMPLEMENTED_CAPABILITIES` is never used
local_studio.rs:483:19: warning: struct `LocalStudioBridge` is never constructed
```

`local_studio_agent_info` was the only reader of `GrantStore::effective`.

The store is still written and read faithfully, so the CLI looks healthy — on a live host right now:

```
$ kittylitter local-studio list
8032ef96…  grants=stats.read,sessions.read,agent.turn  expires=2026-07-28T00:00:00+00:00  revoked=no
88f77a2c…  grants=stats.read,sessions.read,agent.turn  expires=2026-07-28T00:00:00+00:00  revoked=no
ea4a6c63…  grants=stats.read,sessions.read,agent.turn  expires=2026-07-28T00:00:00+00:00  revoked=no
```

Those govern nothing. Any holder of the host pair token can `Connect{agent:"local-studio"}` and get the full app-server surface, and the mobile client additionally forces `AskForApproval::Never` + `SandboxMode::DangerFullAccess` for this runtime. A user revoking a lost phone will be told it worked.

**This PR does not decide the architecture.** It makes the CLI honest in the meantime: every `local-studio` subcommand warns on stderr that grants are not enforced and links #31. Structured stdout is unchanged so scripts keep working.

The real fix is one of the two options in #31 — delete Design A (~5,000 lines, removes 37 dead-code warnings) or re-wire the check. That is a call for the repo owner, not something to land silently overnight.

## 2. The runtime that ships had no tests

Roughly 45 of the ~50 Local-Studio tests in this repo exercise the **dead** gateway path. The live path — `local_studio_bridge` construction, the dispatch arm, `bridge-index` isolation, and `LocalStudioLauncher` — had zero direct coverage.

`LocalStudioLauncher` is the decorator that makes this runtime distinct from `pi` at all. Adds three tests:

- agent-role launch replaces the program, **prepends** rather than replaces the original args, and sets `ELECTRON_RUN_AS_NODE`;
- tool-command role keeps its own program and gains no CLI prefix, but still receives `PI_CODING_AGENT_DIR`;
- an explicit `PI_CODING_AGENT_DIR` is never overridden or duplicated.

```
cargo test -p alleycat --lib
test result: ok. 86 passed; 0 failed  (was 83)
```

The mirror-image decorator on the mobile side gets equivalent coverage in `0xSero/litter#188`.

## 3. This repo had no CI at all

There is no `.github/workflows/` here. Nothing has ever been built or tested automatically — including the code that ships inside every `kittylitter` npm release, since `litter` consumes these crates as a git dependency.

Added one. `cargo build --workspace --all-targets` runs unconditionally; the test step excludes whole crates with a stated reason rather than starting a skip list that quietly grows, so new crates are covered automatically and each exclusion is visible debt:

```
cargo test --workspace \
  --exclude alleycat-bridge-conformance \
  --exclude alleycat-acp-bridge \
  --exclude alleycat-opencode-bridge \
  -- --skip posix_resolver_accepts_dev_suffix_versions
```

**626 tests gate.** Turning CI on found **7 pre-existing failures across 4 crates**, each verified failing against a clean checkout of the branch point — catalogued in #33. Clippy is advisory for now because `crates/alleycat` alone emits 37 dead-code warnings, all from the unreachable gateway in §1.

## 4. The crate does not build on Linux

The very first CI run failed to compile:

```
error[E0609]: no field `pid` on type `GatewayMetadata`
  --> crates/alleycat/src/local_studio.rs:233:68
   = note: available fields are: `url`, `secret`, `controller_id`, `issued_at`
```

`GatewayMetadataFile` (the deserialized `litter-bridge.json`) carries `pid`, but the validated `GatewayMetadata` dropped it — while the `#[cfg(target_os = "linux")]` branch of `bundled_pi_runtime` still reads `metadata.pid` to resolve `/proc/<pid>/{exe,cwd}`. That branch is compiled out on macOS, so this has been broken silently.

Pre-existing and unrelated to §1/§2. Fixed by carrying `pid` through, annotated so it adds no dead-code warning on platforms that resolve via the `.app` bundle.

Relevant to release: `dist-workspace.toml` in `litter` ships `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` kittylitter artifacts.

I could not verify this locally — `x86_64-unknown-linux-gnu` is not installed and the musl targets cannot build `ring` without a cross C toolchain — so CI is the check.

## Note on the downstream pin

`litter` pins all four alleycat crates to `rev = "ad5dba33089c61cdf6cd42f307fffd6609b4ff1d"` on this branch, which has no PR into `main`. The branch has moved **four** commits past that pin since it was set:

```
ad5dba3 (litter's pin) → 0f78f3b → b313786 → 84cb342
```

So downstream release artifacts depend on unreviewed commits on a mutable feature branch. Worth landing this branch into `main` so `litter` can pin a reviewed commit instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
