### PR TITLE
fix(pi): harden Local Studio bridge lifecycle

### DIFF
--- a/crates/alleycat/src/agents.rs
+++ b/crates/alleycat/src/agents.rs
@@ -307,6 +307,7 @@ impl AgentManager {
         let mut pi_builder = PiBridge::builder()
             .agent_bin(PathBuf::from(&snapshot.agents.pi.bin))
             .launcher(pi_launcher)
+            .defer_initial_hydration(true)
             .codex_home(bridge_state.pi.clone());
         if let Some(agent_dir) = pi_agent_dir {
             pi_builder = pi_builder.hydrator(PiHydrator::with_override(agent_dir.join("sessions")));
@@ -336,6 +337,7 @@ impl AgentManager {
             let builder = PiBridge::builder()
                 .agent_bin(runtime.program)
                 .launcher(studio_launcher)
+                .defer_initial_hydration(true)
                 .hydrator(PiHydrator::with_override(agent_dir.join("sessions")))
                 .model_provider_prefix("local-studio")
                 .model_catalog_path(agent_dir.join("models.json"))

--- a/crates/pi-bridge/src/bridge.rs
+++ b/crates/pi-bridge/src/bridge.rs
@@ -128,6 +128,7 @@ pub struct PiBridgeBuilder {
     trust_persisted_cwd: bool,
     hydrator: Option<PiHydrator>,
     rpc_session_listing_only: bool,
+    defer_initial_hydration: bool,
     model_provider_prefixes: Vec<String>,
     model_catalog_path: Option<PathBuf>,
 }
@@ -165,6 +166,16 @@ impl PiBridgeBuilder {
 
     pub fn hydrator(mut self, hydrator: PiHydrator) -> Self {
         self.hydrator = Some(hydrator);
+        self
+    }
+
+    /// Open the persisted thread index immediately and reconcile the full Pi
+    /// session store in the background. Daemon embedders use this so a large
+    /// local history cannot block the control socket or trigger a launchd
+    /// restart loop. Direct bridge consumers retain synchronous hydration by
+    /// default.
+    pub fn defer_initial_hydration(mut self, enabled: bool) -> Self {
+        self.defer_initial_hydration = enabled;
         self
     }
 
@@ -256,8 +267,12 @@ impl PiBridgeBuilder {
                 }
             },
         };
-        let thread_index: Arc<ThreadIndex> =
-            ThreadIndex::open_and_hydrate_with(&codex_home, &hydrator).await?;
+        let defer_initial_hydration = self.defer_initial_hydration && hydrator.sessions.is_none();
+        let thread_index: Arc<ThreadIndex> = if defer_initial_hydration {
+            ThreadIndex::open(&codex_home).await?
+        } else {
+            ThreadIndex::open_and_hydrate_with(&codex_home, &hydrator).await?
+        };
         let scoped_model_provider = self.model_provider_prefixes.first().cloned();
         if let Some(model_provider) = scoped_model_provider.as_deref() {
             thread_index
@@ -286,6 +301,30 @@ impl PiBridgeBuilder {
         } else {
             None
         };
+        if defer_initial_hydration {
+            let index = Arc::clone(&thread_index);
+            let sessions_root = hydrator.override_dir.clone();
+            let model_provider = scoped_model_provider.clone();
+            tokio::spawn(async move {
+                match index.hydrate_from_pi_dir(sessions_root.as_deref()).await {
+                    Ok(added) => {
+                        if let Some(model_provider) = model_provider.as_deref()
+                            && let Err(error) =
+                                index.inner().set_all_model_providers(model_provider).await
+                        {
+                            tracing::warn!(
+                                %error,
+                                "failed to scope deferred pi session hydration"
+                            );
+                        }
+                        tracing::info!(added, "deferred pi session hydration completed");
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "deferred pi session hydration failed");
+                    }
+                }
+            });
+        }
         let thread_index_handle: Arc<dyn ThreadIndexHandle> = thread_index;
 
         Ok(Arc::new(PiBridge {

--- a/crates/pi-bridge/src/handlers/model.rs
+++ b/crates/pi-bridge/src/handlers/model.rs
@@ -38,10 +38,13 @@ pub async fn handle_model_list(
     _params: p::ModelListParams,
 ) -> p::ModelListResponse {
     let pi_models = fetch_models_via_pool(state).await;
+    let default_index = pi_models.iter().position(|model| model.active == Some(true));
     let data = pi_models
         .into_iter()
         .enumerate()
-        .map(|(idx, model)| translate_pi_model(&model, idx == 0))
+        .map(|(idx, model)| {
+            translate_pi_model(&model, default_index.map_or(idx == 0, |default| idx == default))
+        })
         .collect();
     p::ModelListResponse {
         data,
@@ -409,6 +412,8 @@ struct PiAvailableModel {
     label: Option<String>,
     #[serde(default)]
     description: Option<String>,
+    #[serde(default)]
+    active: Option<bool>,
     /// Free-form modalities list pi exposes (`text`, `image`, etc.). We
     /// pass through verbatim and let codex pick what it understands.
     #[serde(default, alias = "input")]
@@ -504,6 +509,35 @@ mod tests {
         assert_eq!(parsed[0].provider.as_deref(), Some("anthropic"));
         assert_eq!(parsed[0].model_id.as_deref(), Some("claude-sonnet-4-6"));
         assert_eq!(parsed[1].id.as_deref(), Some("gpt-5"));
+    }
+
+    #[test]
+    fn active_catalog_model_becomes_the_default() {
+        let models = vec![
+            PiAvailableModel {
+                id: Some("inactive".into()),
+                active: Some(false),
+                ..Default::default()
+            },
+            PiAvailableModel {
+                id: Some("running".into()),
+                active: Some(true),
+                ..Default::default()
+            },
+        ];
+        let default_index = models.iter().position(|model| model.active == Some(true));
+        let translated = models
+            .iter()
+            .enumerate()
+            .map(|(index, model)| {
+                translate_pi_model(
+                    model,
+                    default_index.map_or(index == 0, |default| index == default),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(!translated[0].is_default);
+        assert!(translated[1].is_default);
     }
 
     #[test]

--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -87,7 +87,11 @@ impl ThreadError {
 // thread/start
 // ============================================================================
 
-const INITIAL_SESSION_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+// A running Local Studio process can legitimately spend tens of seconds
+// refreshing a large persisted session index before it services get_state.
+// Keep the correlation slot alive long enough for that valid response instead
+// of discarding it at 30 seconds and leaving thread/start unusable.
+const INITIAL_SESSION_RPC_TIMEOUT: Duration = Duration::from_secs(120);
 const INITIAL_SESSION_CLAIM_ATTEMPTS: usize = 2;
 
 pub async fn handle_thread_start(

--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -42,7 +42,9 @@ use crate::index::{ListFilter, ListSort};
 use crate::pool::pi_protocol as pi;
 use crate::pool::{PiProcessHandle, PoolError};
 use crate::state::ConnectionState;
-use crate::translate::items::{SessionHistoryEntry, translate_messages, translate_session_history};
+use crate::translate::items::{
+    SessionHistoryEntry, merge_compaction_markers, translate_messages, translate_session_history,
+};
 
 /// Errors a `thread/*` handler can produce. Mapped onto JSON-RPC error
 /// codes by the dispatcher in main.rs.
@@ -810,33 +812,44 @@ pub async fn handle_thread_read(
         .ok_or_else(|| ThreadError::NotFound(params.thread_id.clone()))?;
 
     let mut thread = thread_from_entry(&entry);
+    let active_turn_id = super::turn::active_turn_id(&params.thread_id);
     if params.include_turns {
-        // Prefer the live process if one is running for this thread —
-        // it has the freshest state. Otherwise spawn a utility pi and
-        // switch it to the persisted JSONL to read the messages.
-        let handle = match state.pi_pool().get(&params.thread_id).await {
-            Some(h) => h,
-            None => {
-                let cwd = resume_cwd_or_fallback(
-                    &entry.cwd,
-                    &params.thread_id,
-                    state.trust_persisted_cwd(),
-                );
-                let h = state
-                    .pi_pool()
-                    .acquire_utility(Some(&cwd))
-                    .await
-                    .map_err(ThreadError::pool)?;
-                switch_handle_to(&h, &entry.metadata.pi_session_path).await?;
-                h
+        // A live Pi process serializes RPC requests while a prompt is active,
+        // so asking it for messages would block a second client until the
+        // turn completed. Read the append-only session through a utility Pi
+        // during an active turn, then project the in-progress state below.
+        let handle = if active_turn_id.is_some() {
+            let cwd =
+                resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
+            let h = state
+                .pi_pool()
+                .acquire_utility(Some(&cwd))
+                .await
+                .map_err(ThreadError::pool)?;
+            switch_handle_to(&h, &entry.metadata.pi_session_path).await?;
+            h
+        } else {
+            match state.pi_pool().get(&params.thread_id).await {
+                Some(h) => h,
+                None => {
+                    let cwd = resume_cwd_or_fallback(
+                        &entry.cwd,
+                        &params.thread_id,
+                        state.trust_persisted_cwd(),
+                    );
+                    let h = state
+                        .pi_pool()
+                        .acquire_utility(Some(&cwd))
+                        .await
+                        .map_err(ThreadError::pool)?;
+                    switch_handle_to(&h, &entry.metadata.pi_session_path).await?;
+                    h
+                }
             }
         };
         thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
     }
-    apply_live_turn_state(
-        &mut thread,
-        super::turn::active_turn_id(&params.thread_id).as_deref(),
-    );
+    apply_live_turn_state(&mut thread, active_turn_id.as_deref());
     Ok(p::ThreadReadResponse { thread })
 }
 
@@ -1423,9 +1436,9 @@ async fn fetch_turns(
             session_path = %session_path.display(),
             journal_messages = message_count,
             rpc_messages = data.messages.len(),
-            "persisted session history did not match get_messages; using RPC history"
+            "persisted session history did not match get_messages; using RPC messages with persisted compaction markers"
         );
-        return Ok(fallback());
+        return Ok(merge_compaction_markers(fallback(), &history));
     }
     Ok(translate_session_history(&history))
 }

--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -42,7 +42,7 @@ use crate::index::{ListFilter, ListSort};
 use crate::pool::pi_protocol as pi;
 use crate::pool::{PiProcessHandle, PoolError};
 use crate::state::ConnectionState;
-use crate::translate::items::translate_messages;
+use crate::translate::items::{SessionHistoryEntry, translate_messages, translate_session_history};
 
 /// Errors a `thread/*` handler can produce. Mapped onto JSON-RPC error
 /// codes by the dispatcher in main.rs.
@@ -270,7 +270,7 @@ pub async fn handle_thread_resume(
 
     let mut thread = thread_from_entry(&entry);
     if !params.exclude_turns {
-        thread.turns = fetch_turns(&handle).await?;
+        thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
     }
     apply_live_turn_state(
         &mut thread,
@@ -389,7 +389,7 @@ pub async fn handle_thread_fork(
 
     let mut thread = thread_from_entry(&entry);
     if !params.exclude_turns {
-        thread.turns = fetch_turns(&handle).await?;
+        thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
     }
     apply_live_turn_state(
         &mut thread,
@@ -545,16 +545,28 @@ pub async fn handle_thread_compact_start(
         .await
         .ok_or_else(|| ThreadError::NotFound(params.thread_id.clone()))?;
 
-    // Fire pi `compact{}`. Pi runs the compaction asynchronously and
-    // emits `compaction_start` / `compaction_end` events; the turn
-    // pump (#15) translates those into codex `thread/compacted` +
-    // `ContextCompaction` items, so this handler returns success
-    // immediately after pi acks the command preflight.
-    let resp = handle
+    // A normal turn's event pump exits at `agent_end`, so manual compaction
+    // needs its own short-lived subscriber. Subscribe before sending the
+    // command: Pi can emit both lifecycle events before its command response.
+    let events_rx = handle.subscribe_events();
+    let pump = super::turn::spawn_compaction_event_pump(
+        state.clone(),
+        params.thread_id.clone(),
+        Uuid::now_v7().to_string(),
+        events_rx,
+    );
+    let resp = match handle
         .send_request(pi::RpcCommand::Compact(pi::CompactCmd::default()))
         .await
-        .map_err(|e| ThreadError::PiRpc(e.to_string()))?;
+    {
+        Ok(response) => response,
+        Err(error) => {
+            pump.abort();
+            return Err(ThreadError::PiRpc(error.to_string()));
+        }
+    };
     if !resp.success {
+        pump.abort();
         return Err(ThreadError::PiRpc(
             resp.error.unwrap_or_else(|| "compact failed".into()),
         ));
@@ -654,7 +666,7 @@ pub async fn handle_thread_rollback(
         .map_err(ThreadError::from)?;
 
     let mut thread = thread_from_entry(&updated);
-    thread.turns = fetch_turns(&handle).await?;
+    thread.turns = fetch_turns(&handle, &updated.metadata.pi_session_path).await?;
     apply_live_turn_state(
         &mut thread,
         super::turn::active_turn_id(&params.thread_id).as_deref(),
@@ -819,7 +831,7 @@ pub async fn handle_thread_read(
                 h
             }
         };
-        thread.turns = fetch_turns(&handle).await?;
+        thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
     }
     apply_live_turn_state(
         &mut thread,
@@ -871,7 +883,7 @@ pub async fn handle_thread_turns_list(
         }
     };
 
-    let mut turns = fetch_turns(&handle).await?;
+    let mut turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
     apply_live_turn_to_turns(
         &mut turns,
         super::turn::active_turn_id(&params.thread_id).as_deref(),
@@ -1379,7 +1391,10 @@ async fn leaf_user_entry_id(handle: &Arc<PiProcessHandle>) -> Result<String, Thr
         })
 }
 
-async fn fetch_turns(handle: &Arc<PiProcessHandle>) -> Result<Vec<p::Turn>, ThreadError> {
+async fn fetch_turns(
+    handle: &Arc<PiProcessHandle>,
+    session_path: &Path,
+) -> Result<Vec<p::Turn>, ThreadError> {
     let resp = handle
         .send_request(pi::RpcCommand::GetMessages(pi::BareCmd::default()))
         .await
@@ -1394,7 +1409,48 @@ async fn fetch_turns(handle: &Arc<PiProcessHandle>) -> Result<Vec<p::Turn>, Thre
             .ok_or_else(|| ThreadError::PiRpc("missing messages data".into()))?,
     )
     .map_err(|e| ThreadError::PiRpc(format!("decode messages: {e}")))?;
-    Ok(translate_messages(&data.messages))
+    let fallback = || translate_messages(&data.messages);
+    let Ok(raw) = tokio::fs::read_to_string(session_path).await else {
+        return Ok(fallback());
+    };
+    let history = parse_session_history(&raw);
+    let message_count = history
+        .iter()
+        .filter(|entry| matches!(entry, SessionHistoryEntry::Message(_)))
+        .count();
+    if message_count != data.messages.len() {
+        tracing::warn!(
+            session_path = %session_path.display(),
+            journal_messages = message_count,
+            rpc_messages = data.messages.len(),
+            "persisted session history did not match get_messages; using RPC history"
+        );
+        return Ok(fallback());
+    }
+    Ok(translate_session_history(&history))
+}
+
+fn parse_session_history(raw: &str) -> Vec<SessionHistoryEntry> {
+    raw.lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(
+            |entry| match entry.get("type").and_then(|value| value.as_str()) {
+                Some("message") => serde_json::from_value(entry.get("message")?.clone())
+                    .ok()
+                    .map(SessionHistoryEntry::Message),
+                Some("compaction") => {
+                    let id = entry.get("id")?.as_str()?.to_string();
+                    let timestamp_ms = entry
+                        .get("timestamp")
+                        .and_then(|value| value.as_str())
+                        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                        .map(|value| value.timestamp_millis());
+                    Some(SessionHistoryEntry::Compaction { id, timestamp_ms })
+                }
+                _ => None,
+            },
+        )
+        .collect()
 }
 
 /// Default `permissionProfile` value matching codex's stock emission when no
@@ -1445,6 +1501,21 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tokio::sync::mpsc;
+
+    #[test]
+    fn session_history_parser_keeps_compaction_metadata() {
+        let history = parse_session_history(
+            r#"{"type":"compaction","id":"compact-1","timestamp":"2026-07-31T02:18:16.306Z","summary":"done"}"#,
+        );
+        assert_eq!(history.len(), 1);
+        assert!(matches!(
+            &history[0],
+            SessionHistoryEntry::Compaction {
+                id,
+                timestamp_ms: Some(_)
+            } if id == "compact-1"
+        ));
+    }
 
     async fn dummy_state() -> (
         Arc<ConnectionState>,

--- a/crates/pi-bridge/src/handlers/turn.rs
+++ b/crates/pi-bridge/src/handlers/turn.rs
@@ -83,6 +83,8 @@ pub enum TurnError {
     TurnIdMismatch { expected: String, actual: String },
     #[error("no active turn for thread `{0}`")]
     NoActiveTurn(String),
+    #[error("thread `{thread_id}` already has active turn `{turn_id}`")]
+    TurnAlreadyActive { thread_id: String, turn_id: String },
     #[error("input translation failed: {0}")]
     InputTranslation(String),
     #[error("pi rpc error: {0}")]
@@ -98,6 +100,7 @@ impl TurnError {
             | TurnError::TurnIdMismatch { .. }
             | TurnError::ThreadNotLoaded(_)
             | TurnError::NoActiveTurn(_)
+            | TurnError::TurnAlreadyActive { .. }
             | TurnError::InputTranslation(_) => p::error_codes::INVALID_PARAMS,
             TurnError::ReviewUnsupported => p::error_codes::METHOD_NOT_FOUND,
             TurnError::PiRpc(_) => p::error_codes::INTERNAL_ERROR,
@@ -162,7 +165,12 @@ pub async fn handle_turn_start(
         .or(state.defaults().approval_policy)
         .unwrap_or(p::AskForApproval::OnRequest);
 
-    register_active_turn(&params.thread_id, &turn_id, approval_policy.clone());
+    register_active_turn(&params.thread_id, &turn_id, approval_policy.clone()).map_err(
+        |active_turn_id| TurnError::TurnAlreadyActive {
+            thread_id: params.thread_id.clone(),
+            turn_id: active_turn_id,
+        },
+    )?;
 
     // Mark the pool entry active so the LRU reaper doesn't snipe a turn
     // mid-flight. Cleared by the pump on `agent_end`.
@@ -415,14 +423,23 @@ fn now_unix_secs() -> i64 {
         .unwrap_or(0)
 }
 
-fn register_active_turn(thread_id: &str, turn_id: &str, approval_policy: p::AskForApproval) {
-    ACTIVE_TURNS.lock().unwrap().insert(
+fn register_active_turn(
+    thread_id: &str,
+    turn_id: &str,
+    approval_policy: p::AskForApproval,
+) -> Result<(), String> {
+    let mut active_turns = ACTIVE_TURNS.lock().unwrap();
+    if let Some(active) = active_turns.get(thread_id) {
+        return Err(active.turn_id.clone());
+    }
+    active_turns.insert(
         thread_id.to_string(),
         ActiveTurn {
             turn_id: turn_id.to_string(),
             approval_policy,
         },
     );
+    Ok(())
 }
 
 fn active_turn(thread_id: &str) -> Option<ActiveTurn> {
@@ -1007,7 +1024,7 @@ mod tests {
     #[test]
     fn active_turn_table_round_trip() {
         let thread_id = format!("test-{}", Uuid::now_v7());
-        register_active_turn(&thread_id, "tu1", p::AskForApproval::OnRequest);
+        register_active_turn(&thread_id, "tu1", p::AskForApproval::OnRequest).unwrap();
         let active = active_turn(&thread_id).unwrap();
         assert_eq!(active.turn_id, "tu1");
         assert!(matches!(
@@ -1016,6 +1033,19 @@ mod tests {
         ));
         clear_active_turn(&thread_id);
         assert!(active_turn(&thread_id).is_none());
+    }
+
+    #[test]
+    fn active_turn_registration_rejects_overlapping_turns() {
+        let thread_id = format!("test-{}", Uuid::now_v7());
+        register_active_turn(&thread_id, "turn-one", p::AskForApproval::Never).unwrap();
+
+        let existing =
+            register_active_turn(&thread_id, "turn-two", p::AskForApproval::Never).unwrap_err();
+
+        assert_eq!(existing, "turn-one");
+        assert_eq!(active_turn(&thread_id).unwrap().turn_id, "turn-one");
+        clear_active_turn(&thread_id);
     }
 
     #[test]

--- a/crates/pi-bridge/src/handlers/turn.rs
+++ b/crates/pi-bridge/src/handlers/turn.rs
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex as SyncMutex;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -538,6 +538,55 @@ fn spawn_event_pump(args: EventPumpArgs) {
     tokio::spawn(async move {
         run_event_pump(args).await;
     });
+}
+
+pub(crate) fn spawn_compaction_event_pump(
+    state: Arc<ConnectionState>,
+    thread_id: String,
+    turn_id: String,
+    mut events_rx: broadcast::Receiver<pi::PiEvent>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut translator = EventTranslatorState::new(thread_id.clone(), turn_id);
+        loop {
+            let event = match tokio::time::timeout(Duration::from_secs(300), events_rx.recv()).await
+            {
+                Err(_) => {
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        "compaction event pump timed out waiting for lifecycle completion"
+                    );
+                    return;
+                }
+                Ok(result) => match result {
+                    Ok(event) => event,
+                    Err(broadcast::error::RecvError::Lagged(count)) => {
+                        tracing::warn!(
+                            thread_id = %thread_id,
+                            "compaction event pump lagged by {count} events"
+                        );
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return,
+                },
+            };
+
+            let finished = matches!(event, pi::PiEvent::CompactionEnd { .. });
+            if matches!(
+                event,
+                pi::PiEvent::CompactionStart { .. } | pi::PiEvent::CompactionEnd { .. }
+            ) {
+                for notification in translator.translate(event) {
+                    if state_should_emit(&state, &notification) {
+                        let _ = state.send(notification_frame(notification));
+                    }
+                }
+            }
+            if finished {
+                return;
+            }
+        }
+    })
 }
 
 async fn run_event_pump(mut args: EventPumpArgs) {

--- a/crates/pi-bridge/src/translate/items.rs
+++ b/crates/pi-bridge/src/translate/items.rs
@@ -80,6 +80,58 @@ pub(crate) fn translate_session_history(entries: &[SessionHistoryEntry]) -> Vec<
     turns
 }
 
+/// Reinsert persisted compaction markers into a turn list translated from
+/// Pi's live `get_messages` response.
+///
+/// After compaction, `get_messages` intentionally exposes only the compacted
+/// active context, so its message count no longer matches the append-only
+/// JSONL journal. The journal remains authoritative for the marker itself,
+/// while the RPC response remains authoritative for the visible messages.
+pub(crate) fn merge_compaction_markers(
+    mut turns: Vec<Turn>,
+    entries: &[SessionHistoryEntry],
+) -> Vec<Turn> {
+    for entry in entries {
+        let SessionHistoryEntry::Compaction { id, timestamp_ms } = entry else {
+            continue;
+        };
+        if turns.iter().any(|turn| {
+            turn.items
+                .iter()
+                .any(|item| matches!(item, ThreadItem::ContextCompaction { id: item_id } if item_id == id))
+        }) {
+            continue;
+        }
+
+        let insertion_index = timestamp_ms
+            .and_then(|marker_timestamp| {
+                turns.iter().position(|turn| {
+                    turn.started_at
+                        .is_some_and(|started_at| started_at > marker_timestamp)
+                })
+            })
+            .unwrap_or(turns.len());
+        turns.insert(
+            insertion_index,
+            Turn {
+                id: String::new(),
+                items: vec![ThreadItem::ContextCompaction { id: id.clone() }],
+                items_view: crate::codex_proto::default_items_view(),
+                status: crate::codex_proto::TurnStatus::Completed,
+                error: None,
+                started_at: *timestamp_ms,
+                completed_at: *timestamp_ms,
+                duration_ms: Some(0),
+            },
+        );
+    }
+
+    for (index, turn) in turns.iter_mut().enumerate() {
+        turn.id = format!("turn_{index}");
+    }
+    turns
+}
+
 fn translate_messages_from(messages: &[AgentMessage], turn_offset: usize) -> Vec<Turn> {
     let tool_results = index_tool_results(messages);
 
@@ -653,6 +705,31 @@ mod tests {
         assert_eq!(turns[1].started_at, Some(200));
         assert_eq!(turns[2].id, "turn_2");
         assert_eq!(turns[2].items[0].id(), "user_2");
+    }
+
+    #[test]
+    fn compacted_rpc_history_merges_persisted_marker_by_timestamp() {
+        let before = user(UserMessageContent::Text("before".into()), 100);
+        let before_reply = assistant_with_blocks(Vec::new(), 150);
+        let after = user(UserMessageContent::Text("after".into()), 300);
+        let after_reply = assistant_with_blocks(Vec::new(), 350);
+        let rpc_turns = translate_messages(&[before, before_reply, after, after_reply]);
+        let turns = merge_compaction_markers(
+            rpc_turns,
+            &[SessionHistoryEntry::Compaction {
+                id: "compact-1".into(),
+                timestamp_ms: Some(200),
+            }],
+        );
+
+        assert_eq!(turns.len(), 3);
+        assert_eq!(turns[0].id, "turn_0");
+        assert_eq!(turns[1].id, "turn_1");
+        assert!(matches!(
+            &turns[1].items[0],
+            ThreadItem::ContextCompaction { id } if id == "compact-1"
+        ));
+        assert_eq!(turns[2].id, "turn_2");
     }
 
     #[test]

--- a/crates/pi-bridge/src/translate/items.rs
+++ b/crates/pi-bridge/src/translate/items.rs
@@ -35,8 +35,52 @@ use crate::pool::pi_protocol::{
 use crate::translate::tool_call::{CodexToolKind, classify};
 use crate::translate::turn_terminal_state;
 
+#[derive(Debug, Clone)]
+pub(crate) enum SessionHistoryEntry {
+    Message(AgentMessage),
+    Compaction {
+        id: String,
+        timestamp_ms: Option<i64>,
+    },
+}
+
 /// Translate a flat pi message stream into the per-turn codex shape.
 pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
+    translate_messages_from(messages, 0)
+}
+
+/// Translate Pi's persisted JSONL history, preserving compaction markers that
+/// `get_messages` intentionally omits.
+pub(crate) fn translate_session_history(entries: &[SessionHistoryEntry]) -> Vec<Turn> {
+    let mut turns = Vec::new();
+    let mut messages = Vec::new();
+
+    for entry in entries {
+        match entry {
+            SessionHistoryEntry::Message(message) => messages.push(message.clone()),
+            SessionHistoryEntry::Compaction { id, timestamp_ms } => {
+                turns.extend(translate_messages_from(&messages, turns.len()));
+                messages.clear();
+
+                let turn_index = turns.len();
+                turns.push(Turn {
+                    id: format!("turn_{turn_index}"),
+                    items: vec![ThreadItem::ContextCompaction { id: id.clone() }],
+                    items_view: crate::codex_proto::default_items_view(),
+                    status: crate::codex_proto::TurnStatus::Completed,
+                    error: None,
+                    started_at: *timestamp_ms,
+                    completed_at: *timestamp_ms,
+                    duration_ms: Some(0),
+                });
+            }
+        }
+    }
+    turns.extend(translate_messages_from(&messages, turns.len()));
+    turns
+}
+
+fn translate_messages_from(messages: &[AgentMessage], turn_offset: usize) -> Vec<Turn> {
     let tool_results = index_tool_results(messages);
 
     let mut turns: Vec<Turn> = Vec::new();
@@ -61,6 +105,7 @@ pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
                 } else {
                     flush_turn(
                         &mut turns,
+                        turn_offset,
                         &mut current_items,
                         &mut current_started_at,
                         &mut current_completed_at,
@@ -73,7 +118,11 @@ pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
                     user_index = 0;
                     saw_assistant_or_tool = false;
                 }
-                current_items.push(user_message_to_item(user, turns.len(), user_index));
+                current_items.push(user_message_to_item(
+                    user,
+                    turn_offset + turns.len(),
+                    user_index,
+                ));
             }
             AgentMessage::Assistant(asst) => {
                 saw_assistant_or_tool = true;
@@ -83,7 +132,7 @@ pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
                 current_completed_at = Some(asst.timestamp);
                 current_stop_reason = Some(asst.stop_reason);
                 current_error_message = asst.error_message.clone();
-                let turn_index = turns.len();
+                let turn_index = turn_offset + turns.len();
                 push_assistant_items(
                     asst,
                     turn_index,
@@ -110,6 +159,7 @@ pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
 
     flush_turn(
         &mut turns,
+        turn_offset,
         &mut current_items,
         &mut current_started_at,
         &mut current_completed_at,
@@ -121,6 +171,7 @@ pub fn translate_messages(messages: &[AgentMessage]) -> Vec<Turn> {
 
 fn flush_turn(
     turns: &mut Vec<Turn>,
+    turn_offset: usize,
     items: &mut Vec<ThreadItem>,
     started_at: &mut Option<i64>,
     completed_at: &mut Option<i64>,
@@ -139,7 +190,7 @@ fn flush_turn(
     let message = error_message.take();
     let (status, error) = turn_terminal_state(stop_reason.take(), message.as_deref());
     turns.push(Turn {
-        id: format!("turn_{}", turns.len()),
+        id: format!("turn_{}", turn_offset + turns.len()),
         items: std::mem::take(items),
         items_view: crate::codex_proto::default_items_view(),
         status,
@@ -576,6 +627,32 @@ mod tests {
     #[test]
     fn empty_input_yields_no_turns() {
         assert!(translate_messages(&[]).is_empty());
+    }
+
+    #[test]
+    fn persisted_compaction_stays_between_surrounding_turns() {
+        let before = user(UserMessageContent::Text("before".into()), 100);
+        let after = user(UserMessageContent::Text("after".into()), 300);
+        let turns = translate_session_history(&[
+            SessionHistoryEntry::Message(before),
+            SessionHistoryEntry::Compaction {
+                id: "compact-1".into(),
+                timestamp_ms: Some(200),
+            },
+            SessionHistoryEntry::Message(after),
+        ]);
+
+        assert_eq!(turns.len(), 3);
+        assert_eq!(turns[0].id, "turn_0");
+        assert_eq!(turns[0].items[0].id(), "user_0");
+        assert_eq!(turns[1].id, "turn_1");
+        assert!(matches!(
+            &turns[1].items[0],
+            ThreadItem::ContextCompaction { id } if id == "compact-1"
+        ));
+        assert_eq!(turns[1].started_at, Some(200));
+        assert_eq!(turns[2].id, "turn_2");
+        assert_eq!(turns[2].items[0].id(), "user_2");
     }
 
     #[test]


### PR DESCRIPTION
## What

Harden the Pi bridge lifecycle used by Local Studio and Litter:

- extend the initial Pi session RPC response window from 30 seconds to 120 seconds
- open the persisted thread index immediately and reconcile the full Pi session store in the background for daemon-managed runtimes
- reject a second `turn/start` while the same thread already has an active turn
- let a fresh `thread/read` inspect an active session without blocking behind its prompt
- forward manual compaction item lifecycles through the mobile connection
- preserve persisted compaction markers when sessions are rehydrated
- mark the controller's active catalog model as the default mobile selection

## Why

Local Studio can legitimately spend more than 30 seconds refreshing a large persisted session index before answering `get_state`. The bridge previously removed the pending correlation slot at 30 seconds, then discarded the valid late response. A 597-session history also made synchronous hydration hold daemon startup long enough for launchd to restart it.

A timed-out client could send another turn on the same thread while the original turn was active. Pi queued the prompt, causing reasoning, content, and tool events to appear under the wrong request. A second client also could not read the in-progress session because Pi serializes requests behind the active prompt.

Manual compaction succeeded in Pi's JSONL journal but did not reach mobile clients after the normal turn event pump exited. Rehydration then preferred `get_messages`, which omits compaction entries.

Finally, Local Studio's controller catalog identifies the running model with `active: true`, but the bridge always marked the first catalog row as default. Fresh Litter sessions could therefore select an inactive model and fail with `model_not_running`.

## Impact

Daemon readiness no longer waits on full-history scanning. New sessions tolerate slow initial refreshes, each thread has one unambiguous active turn, fresh clients can inspect an in-progress turn, and compaction remains ordered and visible after reconnect. The model picker defaults to the controller's running model when that signal is available.

## Testing

- `cargo test -p alleycat-pi-bridge -p alleycat`
- all Pi bridge unit and integration tests passed, including streaming, tool lifecycle, compaction, resume, active-read, and cross-cwd coverage
- Litter's live iroh/JSON-RPC acceptance harness passed 20/20 against Local Studio, including session handoff in both directions, mid-turn reconnect, ordered reasoning/content/tool events, file creation, compaction, and post-compaction hydration
