### PR TITLE
probe: persist client identity across reconnect checks

### DIFF
--- a/crates/alleycat/src/cli/probe.rs
+++ b/crates/alleycat/src/cli/probe.rs
@@ -11,8 +11,10 @@
 //!
 //! Identity: reads the daemon's local `host.toml` + `host.key` so the probe
 //! authenticates with the same node id and token a phone holding the QR
-//! payload would. Generates a fresh client iroh identity each run.
+//! payload would. Generates a fresh client iroh identity each run unless a
+//! persistent `--client-key-file` is supplied.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
@@ -99,6 +101,12 @@ pub struct ProbeArgs {
     /// existing session and exercise replay/drift paths.
     #[arg(long)]
     pub repeat_resume_from: Option<u64>,
+    /// Persist the probe's client identity at this path. Reusing the same
+    /// file across invocations simulates reconnects from one paired phone;
+    /// without this option each probe invocation intentionally uses a fresh
+    /// identity.
+    #[arg(long, value_name = "PATH")]
+    pub client_key_file: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -143,7 +151,7 @@ pub async fn run(args: ProbeArgs) -> anyhow::Result<()> {
         relay.as_deref().unwrap_or("<iroh default>")
     );
 
-    let endpoint = build_client_endpoint().await?;
+    let endpoint = build_client_endpoint(args.client_key_file.as_deref()).await?;
     let result = probe_with_endpoint(&endpoint, node_id, relay.as_deref(), &token, &args).await;
     endpoint.close().await;
     result
@@ -758,8 +766,15 @@ fn print_inbound(value: &Value) {
     println!("← {pretty}");
 }
 
-async fn build_client_endpoint() -> anyhow::Result<Endpoint> {
-    let secret = SecretKey::generate();
+async fn build_client_endpoint(
+    client_key_file: Option<&std::path::Path>,
+) -> anyhow::Result<Endpoint> {
+    let secret = match client_key_file {
+        Some(path) => crate::state::load_or_create_secret_key_at(path)
+            .await
+            .with_context(|| format!("loading probe client identity {}", path.display()))?,
+        None => SecretKey::generate(),
+    };
     Endpoint::builder(presets::N0)
         .secret_key(secret)
         .alpns(vec![ALLEYCAT_ALPN.to_vec()])

--- a/crates/alleycat/src/state.rs
+++ b/crates/alleycat/src/state.rs
@@ -10,12 +10,20 @@ use crate::paths;
 
 pub async fn load_or_create_secret_key() -> anyhow::Result<SecretKey> {
     let path = paths::host_key_file()?;
-    match fs::read_to_string(&path).await {
+    load_or_create_secret_key_at(&path).await
+}
+
+/// Load a stable iroh identity from `path`, creating it with owner-only
+/// permissions when it does not exist. The daemon uses the standard host-key
+/// path; diagnostic clients may opt into their own persistent identity so a
+/// reconnect is authenticated as the same device.
+pub(crate) async fn load_or_create_secret_key_at(path: &Path) -> anyhow::Result<SecretKey> {
+    match fs::read_to_string(path).await {
         Ok(raw) => parse_secret_key(raw.trim())
-            .with_context(|| format!("parsing host key {}", path.display())),
+            .with_context(|| format!("parsing secret key {}", path.display())),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             let key = SecretKey::generate();
-            write_secret_key(&path, &key).await?;
+            write_secret_key(path, &key).await?;
             Ok(key)
         }
         Err(error) => Err(error).with_context(|| format!("reading {}", path.display())),
@@ -139,5 +147,24 @@ mod tests {
         let key = SecretKey::generate();
         let parsed = parse_secret_key(&hex::encode(key.to_bytes())).unwrap();
         assert_eq!(parsed.public(), key.public());
+    }
+
+    #[tokio::test]
+    async fn path_loader_reuses_the_same_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("probe.key");
+
+        let first = load_or_create_secret_key_at(&path).await.unwrap();
+        let second = load_or_create_secret_key_at(&path).await.unwrap();
+
+        assert_eq!(first.public(), second.public());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Make multi-invocation production probes model a real paired phone instead of generating a different cryptographic client identity for every command.

## Changes

- add an opt-in `--client-key-file` to `alleycat probe`
- reuse the existing atomic owner-only secret-key writer
- test identity reuse and Unix `0600` permissions

## Verification

- `cargo test -p alleycat path_loader_reuses_the_same_identity`
- `cargo build -p alleycat`
- two separate Local Studio probes using one key reattached as `Resumed`; a detached 10-second shell tool completed and rehydrated its command output and final assistant response
