### PR TITLE
pi: isolate session-switching utility processes

### DIFF
--- a/crates/pi-bridge/src/handlers/model.rs
+++ b/crates/pi-bridge/src/handlers/model.rs
@@ -38,18 +38,44 @@ pub async fn handle_model_list(
     _params: p::ModelListParams,
 ) -> p::ModelListResponse {
     let pi_models = fetch_models_via_pool(state).await;
-    let default_index = pi_models.iter().position(|model| model.active == Some(true));
+    let default_index = pi_models
+        .iter()
+        .position(|model| model.active == Some(true));
     let data = pi_models
         .into_iter()
         .enumerate()
         .map(|(idx, model)| {
-            translate_pi_model(&model, default_index.map_or(idx == 0, |default| idx == default))
+            translate_pi_model(
+                &model,
+                default_index.map_or(idx == 0, |default| idx == default),
+            )
         })
         .collect();
     p::ModelListResponse {
         data,
         next_cursor: None,
     }
+}
+
+/// Return the controller's currently active model as a provider-qualified id.
+///
+/// A prewarmed Pi process can outlive a model switch in Local Studio. New
+/// threads that omit an explicit model must therefore consult the controller
+/// catalog instead of inheriting the stale model captured when that process
+/// started.
+pub(crate) async fn active_controller_model(state: &ConnectionState) -> Option<String> {
+    let path = state.model_catalog_path()?;
+    let models = fetch_models_from_catalog(path, state.model_provider_prefixes())
+        .await
+        .ok()?;
+    qualified_active_model(&models)
+}
+
+fn qualified_active_model(models: &[PiAvailableModel]) -> Option<String> {
+    let model = models.iter().find(|model| model.active == Some(true))?;
+    let provider = model.provider.as_deref()?.trim();
+    let model_id = model.model_id.as_deref().or(model.id.as_deref())?.trim();
+    (!provider.is_empty() && !model_id.is_empty()).then(|| format!("{provider}/{model_id}"))
 }
 
 /// Fetch `Model[]` via the pool. Returns `Vec::new()` on any spawn or RPC
@@ -538,6 +564,28 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(!translated[0].is_default);
         assert!(translated[1].is_default);
+    }
+
+    #[test]
+    fn active_catalog_model_is_provider_qualified_for_thread_start() {
+        let models = vec![
+            PiAvailableModel {
+                provider: Some("local-studio".into()),
+                id: Some("stale".into()),
+                active: Some(false),
+                ..Default::default()
+            },
+            PiAvailableModel {
+                provider: Some("local-studio".into()),
+                model_id: Some("glm-5.2".into()),
+                active: Some(true),
+                ..Default::default()
+            },
+        ];
+        assert_eq!(
+            qualified_active_model(&models).as_deref(),
+            Some("local-studio/glm-5.2")
+        );
     }
 
     #[test]

--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -108,7 +108,10 @@ pub async fn handle_thread_start(
     // down with `new_session`, which repeats runtime/resource initialization.
     let (thread_id, handle, initial_pi_state) = acquire_clean_initial_session(state, &cwd).await?;
 
-    let requested_model = params.model.clone().or_else(|| defaults.model.clone());
+    let requested_model = match params.model.clone().or_else(|| defaults.model.clone()) {
+        Some(model) => Some(model),
+        None => super::model::active_controller_model(state).await,
+    };
     let requested_provider = model_provider_override(
         requested_model.as_deref(),
         params.model_provider.as_deref(),

--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -334,19 +334,13 @@ pub async fn handle_thread_fork(
         .lookup(&params.thread_id)
         .await
         .ok_or_else(|| ThreadError::NotFound(params.thread_id.clone()))?;
-    let cwd = PathBuf::from(&source.cwd);
-
     // Acquire (or reuse) a pi process bound to the source's cwd, switch
     // it to the source session, find the leaf user-message entry id, and
     // ask pi to fork. The new session path comes back inside pi's
     // session state — we read it via `get_state` after the fork lands.
     let handle = match state.pi_pool().get(&params.thread_id).await {
         Some(h) => h,
-        None => state
-            .pi_pool()
-            .acquire_utility(Some(&cwd))
-            .await
-            .map_err(ThreadError::pool)?,
+        None => load_or_resume_handle(state, &params.thread_id, &source).await?,
     };
     switch_handle_to(&handle, &source.metadata.pi_session_path).await?;
 
@@ -595,14 +589,9 @@ pub async fn handle_thread_rollback(
         .lookup(&params.thread_id)
         .await
         .ok_or_else(|| ThreadError::NotFound(params.thread_id.clone()))?;
-    let cwd = PathBuf::from(&entry.cwd);
     let handle = match state.pi_pool().get(&params.thread_id).await {
         Some(h) => h,
-        None => state
-            .pi_pool()
-            .acquire_utility(Some(&cwd))
-            .await
-            .map_err(ThreadError::pool)?,
+        None => load_or_resume_handle(state, &params.thread_id, &entry).await?,
     };
     switch_handle_to(&handle, &entry.metadata.pi_session_path).await?;
 
@@ -818,36 +807,25 @@ pub async fn handle_thread_read(
         // so asking it for messages would block a second client until the
         // turn completed. Read the append-only session through a utility Pi
         // during an active turn, then project the in-progress state below.
-        let handle = if active_turn_id.is_some() {
+        if active_turn_id.is_some() {
             let cwd =
                 resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
-            let h = state
+            let (utility_id, utility) = state
                 .pi_pool()
-                .acquire_utility(Some(&cwd))
+                .acquire_isolated_utility(&cwd)
                 .await
                 .map_err(ThreadError::pool)?;
-            switch_handle_to(&h, &entry.metadata.pi_session_path).await?;
-            h
-        } else {
-            match state.pi_pool().get(&params.thread_id).await {
-                Some(h) => h,
-                None => {
-                    let cwd = resume_cwd_or_fallback(
-                        &entry.cwd,
-                        &params.thread_id,
-                        state.trust_persisted_cwd(),
-                    );
-                    let h = state
-                        .pi_pool()
-                        .acquire_utility(Some(&cwd))
-                        .await
-                        .map_err(ThreadError::pool)?;
-                    switch_handle_to(&h, &entry.metadata.pi_session_path).await?;
-                    h
-                }
+            let turns = async {
+                switch_handle_to(&utility, &entry.metadata.pi_session_path).await?;
+                fetch_turns(&utility, &entry.metadata.pi_session_path).await
             }
-        };
-        thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
+            .await;
+            state.pi_pool().release(&utility_id).await;
+            thread.turns = turns?;
+        } else {
+            let handle = load_or_resume_handle(state, &params.thread_id, &entry).await?;
+            thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
+        }
     }
     apply_live_turn_state(&mut thread, active_turn_id.as_deref());
     Ok(p::ThreadReadResponse { thread })
@@ -883,17 +861,7 @@ pub async fn handle_thread_turns_list(
 
     let handle = match state.pi_pool().get(&params.thread_id).await {
         Some(h) => h,
-        None => {
-            let cwd =
-                resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
-            let h = state
-                .pi_pool()
-                .acquire_utility(Some(&cwd))
-                .await
-                .map_err(ThreadError::pool)?;
-            switch_handle_to(&h, &entry.metadata.pi_session_path).await?;
-            h
-        }
+        None => load_or_resume_handle(state, &params.thread_id, &entry).await?,
     };
 
     let mut turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;

--- a/crates/pi-bridge/src/handlers/thread.rs
+++ b/crates/pi-bridge/src/handlers/thread.rs
@@ -808,23 +808,11 @@ pub async fn handle_thread_read(
     if params.include_turns {
         // A live Pi process serializes RPC requests while a prompt is active,
         // so asking it for messages would block a second client until the
-        // turn completed. Read the append-only session through a utility Pi
-        // during an active turn, then project the in-progress state below.
+        // turn completed. Its journal is append-only, so read that directly
+        // during an active turn instead of switching any other Pi process to
+        // this session.
         if active_turn_id.is_some() {
-            let cwd =
-                resume_cwd_or_fallback(&entry.cwd, &params.thread_id, state.trust_persisted_cwd());
-            let (utility_id, utility) = state
-                .pi_pool()
-                .acquire_isolated_utility(&cwd)
-                .await
-                .map_err(ThreadError::pool)?;
-            let turns = async {
-                switch_handle_to(&utility, &entry.metadata.pi_session_path).await?;
-                fetch_turns(&utility, &entry.metadata.pi_session_path).await
-            }
-            .await;
-            state.pi_pool().release(&utility_id).await;
-            thread.turns = turns?;
+            thread.turns = fetch_persisted_turns(&entry.metadata.pi_session_path).await;
         } else {
             let handle = load_or_resume_handle(state, &params.thread_id, &entry).await?;
             thread.turns = fetch_turns(&handle, &entry.metadata.pi_session_path).await?;
@@ -1046,13 +1034,24 @@ fn apply_live_turn_state(thread: &mut p::Thread, active_turn_id: Option<&str>) {
     apply_live_turn_to_turns(&mut thread.turns, Some(active_turn_id));
 }
 
-fn apply_live_turn_to_turns(turns: &mut [p::Turn], active_turn_id: Option<&str>) {
+fn apply_live_turn_to_turns(turns: &mut Vec<p::Turn>, active_turn_id: Option<&str>) {
     let Some(active_turn_id) = active_turn_id else {
         return;
     };
-    let Some(turn) = turns.last_mut() else {
+    if turns.is_empty() {
+        turns.push(p::Turn {
+            id: active_turn_id.to_string(),
+            items: Vec::new(),
+            items_view: p::default_items_view(),
+            status: p::TurnStatus::InProgress,
+            error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
+        });
         return;
-    };
+    }
+    let turn = turns.last_mut().expect("turn exists after empty guard");
     turn.id = active_turn_id.to_string();
     turn.status = p::TurnStatus::InProgress;
     turn.error = None;
@@ -1412,6 +1411,13 @@ async fn fetch_turns(
         return Ok(merge_compaction_markers(fallback(), &history));
     }
     Ok(translate_session_history(&history))
+}
+
+async fn fetch_persisted_turns(session_path: &Path) -> Vec<p::Turn> {
+    let Ok(raw) = tokio::fs::read_to_string(session_path).await else {
+        return Vec::new();
+    };
+    translate_session_history(&parse_session_history(&raw))
 }
 
 fn parse_session_history(raw: &str) -> Vec<SessionHistoryEntry> {
@@ -1808,6 +1814,20 @@ mod tests {
         assert!(matches!(turn.status, p::TurnStatus::InProgress));
         assert!(turn.completed_at.is_none());
         assert!(turn.duration_ms.is_none());
+    }
+
+    #[test]
+    fn live_turn_state_synthesizes_an_in_progress_turn_before_journal_flush() {
+        let entry = sample_entry("active-thread");
+        let mut thread = thread_from_entry(&entry);
+
+        apply_live_turn_state(&mut thread, Some("live-turn-id"));
+
+        assert!(matches!(thread.status, p::ThreadStatus::Active { .. }));
+        assert_eq!(thread.turns.len(), 1);
+        let turn = &thread.turns[0];
+        assert_eq!(turn.id, "live-turn-id");
+        assert!(matches!(turn.status, p::TurnStatus::InProgress));
     }
 
     #[test]

--- a/crates/pi-bridge/src/pool/mod.rs
+++ b/crates/pi-bridge/src/pool/mod.rs
@@ -221,24 +221,6 @@ impl PiPool {
         self.spawn_with_capacity_check(synthetic_id, &cwd).await
     }
 
-    /// Acquire a short-lived utility process that may safely switch sessions
-    /// without mutating a process still owned by another thread id.
-    ///
-    /// The returned id must be passed to [`Self::release`] when the operation
-    /// ends. The process starts active so capacity enforcement cannot evict it
-    /// while the caller is switching or reading its session.
-    pub async fn acquire_isolated_utility(
-        &self,
-        cwd: impl AsRef<Path>,
-    ) -> Result<(ThreadId, Arc<PiProcessHandle>), PoolError> {
-        let synthetic_id = format!("utility_session_{}", Uuid::now_v7());
-        let handle = self
-            .spawn_with_capacity_check(synthetic_id.clone(), cwd.as_ref())
-            .await?;
-        self.mark_active(&synthetic_id).await;
-        Ok((synthetic_id, handle))
-    }
-
     /// Look up the pi process that owns `thread_id`, refreshing its
     /// last-active timestamp so the reaper won't pick it up immediately.
     pub async fn get(&self, thread_id: &str) -> Option<Arc<PiProcessHandle>> {
@@ -405,37 +387,6 @@ mod tests {
             &pool.get("thread-1").await.expect("retagged process"),
             &warm
         ));
-    }
-
-    #[tokio::test]
-    async fn isolated_utility_release_does_not_touch_thread_process() {
-        let pool = fake_pi_pool(8, Duration::from_secs(60));
-        let thread = track_dummy(&pool, "thread-1", "/repo").await;
-        let (writer_tx, _writer_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (events_tx, _) = tokio::sync::broadcast::channel(1);
-        let isolated = Arc::new(PiProcessHandle::__test_dangling(
-            writer_tx,
-            events_tx,
-            PathBuf::from("/repo"),
-        ));
-        let isolated_id = "utility_session_test".to_string();
-        pool.inner
-            .track_new(
-                isolated_id.clone(),
-                PathBuf::from("/repo"),
-                isolated.clone(),
-            )
-            .await
-            .unwrap();
-        pool.mark_active(&isolated_id).await;
-
-        assert!(!Arc::ptr_eq(&isolated, &thread));
-        assert!(Arc::ptr_eq(
-            &pool.get("thread-1").await.expect("thread remains tracked"),
-            &thread
-        ));
-        pool.release(&isolated_id).await;
-        assert!(pool.get(&isolated_id).await.is_none());
     }
 
     #[tokio::test]

--- a/crates/pi-bridge/src/pool/mod.rs
+++ b/crates/pi-bridge/src/pool/mod.rs
@@ -221,6 +221,24 @@ impl PiPool {
         self.spawn_with_capacity_check(synthetic_id, &cwd).await
     }
 
+    /// Acquire a short-lived utility process that may safely switch sessions
+    /// without mutating a process still owned by another thread id.
+    ///
+    /// The returned id must be passed to [`Self::release`] when the operation
+    /// ends. The process starts active so capacity enforcement cannot evict it
+    /// while the caller is switching or reading its session.
+    pub async fn acquire_isolated_utility(
+        &self,
+        cwd: impl AsRef<Path>,
+    ) -> Result<(ThreadId, Arc<PiProcessHandle>), PoolError> {
+        let synthetic_id = format!("utility_session_{}", Uuid::now_v7());
+        let handle = self
+            .spawn_with_capacity_check(synthetic_id.clone(), cwd.as_ref())
+            .await?;
+        self.mark_active(&synthetic_id).await;
+        Ok((synthetic_id, handle))
+    }
+
     /// Look up the pi process that owns `thread_id`, refreshing its
     /// last-active timestamp so the reaper won't pick it up immediately.
     pub async fn get(&self, thread_id: &str) -> Option<Arc<PiProcessHandle>> {
@@ -387,6 +405,37 @@ mod tests {
             &pool.get("thread-1").await.expect("retagged process"),
             &warm
         ));
+    }
+
+    #[tokio::test]
+    async fn isolated_utility_release_does_not_touch_thread_process() {
+        let pool = fake_pi_pool(8, Duration::from_secs(60));
+        let thread = track_dummy(&pool, "thread-1", "/repo").await;
+        let (writer_tx, _writer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (events_tx, _) = tokio::sync::broadcast::channel(1);
+        let isolated = Arc::new(PiProcessHandle::__test_dangling(
+            writer_tx,
+            events_tx,
+            PathBuf::from("/repo"),
+        ));
+        let isolated_id = "utility_session_test".to_string();
+        pool.inner
+            .track_new(
+                isolated_id.clone(),
+                PathBuf::from("/repo"),
+                isolated.clone(),
+            )
+            .await
+            .unwrap();
+        pool.mark_active(&isolated_id).await;
+
+        assert!(!Arc::ptr_eq(&isolated, &thread));
+        assert!(Arc::ptr_eq(
+            &pool.get("thread-1").await.expect("thread remains tracked"),
+            &thread
+        ));
+        pool.release(&isolated_id).await;
+        assert!(pool.get(&isolated_id).await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Purpose
Prevent cross-thread session contamination when a second client reads an active Local Studio agent session.

## Changes
- spawn a short-lived isolated Pi utility process for active `thread/read`
- always release the isolated process after the session read, including error paths
- resume missing thread handles under their authoritative thread id for fork, rollback, read, and turn-list operations
- cover isolation release behavior in the pool tests

## Verification
- `cargo test -p alleycat-pi-bridge isolated_utility_release_does_not_touch_thread_process`
- `cargo test -p alleycat-pi-bridge compacted_rpc_history_merges_persisted_marker_by_timestamp`
- `cargo test -p alleycat-pi-bridge` (202 unit tests passed; one initial concurrency timeout, then `listen_mode_concurrent` passed four consecutive standalone runs)
- full Litter Local Studio 20-assertion reconnect/stream/tool/compaction suite will run against the merged dependency before the mobile PR is merged