### PR TITLE
amp: support current agent modes

### DIFF
--- a/crates/alleycat/src/agent_manifest.rs
+++ b/crates/alleycat/src/agent_manifest.rs
@@ -94,10 +94,10 @@ pub const MANIFESTS: &[AgentManifest] = &[
         title: Some("Amp"),
         is_beta: true,
         sort_order: 2,
-        description: Some("Sourcegraph Amp."),
+        description: Some("Frontier coding agent."),
         aliases: &["ampcode", "amp-code", "amp_code", "amp code"],
-        locks_reasoning_effort_after_activity: true,
-        visible_modes: Some(&["smart", "rush", "deep"]),
+        locks_reasoning_effort_after_activity: false,
+        visible_modes: Some(&["low", "medium", "high", "ultra"]),
         supports_ssh_bridge: false,
         uses_direct_codex_port: false,
         supports_thread_permission_overrides: false,
@@ -219,4 +219,32 @@ pub const MANIFESTS: &[AgentManifest] = &[
 
 pub fn manifest_for(name: &str) -> Option<&'static AgentManifest> {
     MANIFESTS.iter().find(|m| m.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn amp_manifest_advertises_current_modes_without_effort_lock() {
+        let amp = manifest_for("amp").unwrap();
+        assert_eq!(amp.description, Some("Frontier coding agent."));
+        assert_eq!(
+            amp.visible_modes,
+            Some(&["low", "medium", "high", "ultra"][..])
+        );
+        assert!(!amp.locks_reasoning_effort_after_activity);
+
+        let capabilities = amp.capabilities();
+        assert_eq!(
+            capabilities.visible_modes,
+            Some(vec![
+                "low".to_string(),
+                "medium".to_string(),
+                "high".to_string(),
+                "ultra".to_string(),
+            ])
+        );
+        assert!(!capabilities.locks_reasoning_effort_after_activity);
+    }
 }

--- a/crates/amp-bridge/src/bridge.rs
+++ b/crates/amp-bridge/src/bridge.rs
@@ -26,7 +26,7 @@ use crate::state::{ConnectionState, ThreadDefaults};
 
 const DEFAULT_AMP_BIN: &str = "amp";
 const MODEL_PROVIDER: &str = "amp";
-const DEFAULT_MODEL: &str = "smart";
+const DEFAULT_MODEL: &str = "medium";
 const USER_AGENT: &str = concat!("alleycat-amp-bridge/", env!("CARGO_PKG_VERSION"));
 
 pub type ThreadIndex = CoreThreadIndex<AmpSessionRef>;
@@ -66,7 +66,6 @@ struct ThreadStartShape {
     approval_policy: p::AskForApproval,
     approvals_reviewer: p::ApprovalsReviewer,
     sandbox: p::SandboxPolicy,
-    reasoning_effort: Option<p::ReasoningEffort>,
 }
 
 impl AmpBridge {
@@ -465,20 +464,12 @@ impl AmpBridge {
             .approvals_reviewer
             .unwrap_or(p::ApprovalsReviewer::AutoReview);
         let sandbox_mode = params.sandbox.unwrap_or(p::SandboxMode::WorkspaceWrite);
-        let reasoning_effort = select_amp_reasoning_effort(
-            &model,
-            amp_effort_from_additional(&params.additional),
-            None,
-            None,
-        )?;
-
         state.update_defaults(|defaults| {
             defaults.model = Some(model.clone());
             defaults.model_provider = Some(MODEL_PROVIDER.to_string());
             defaults.approval_policy = Some(approval_policy.clone());
             defaults.approvals_reviewer = Some(approvals_reviewer);
             defaults.sandbox = Some(sandbox_mode);
-            defaults.reasoning_effort = reasoning_effort;
             defaults.service_name = params.service_name.clone();
             defaults.system_prompt = params
                 .developer_instructions
@@ -501,7 +492,7 @@ impl AmpBridge {
                 amp_thread_id: None,
                 amp_thread_path: Some(transcript_path(&self.transcripts_dir, &thread_id)),
                 model: Some(model.clone()),
-                reasoning_effort: reasoning_effort_metadata(reasoning_effort),
+                reasoning_effort: None,
             },
         };
         self.thread_index
@@ -517,7 +508,6 @@ impl AmpBridge {
             approval_policy,
             approvals_reviewer,
             sandbox: sandbox_policy(sandbox_mode),
-            reasoning_effort,
         };
         emit(
             state,
@@ -556,25 +546,8 @@ impl AmpBridge {
                 .or(defaults.model.as_deref()),
         );
         let model_changed = old_model.as_deref() != Some(model.as_str());
-        let stored_effort = (!model_changed)
-            .then(|| {
-                entry
-                    .metadata
-                    .reasoning_effort
-                    .as_deref()
-                    .and_then(parse_amp_reasoning_effort)
-            })
-            .flatten();
-        let reasoning_effort = select_amp_reasoning_effort(
-            &model,
-            amp_effort_from_additional(&params.additional),
-            stored_effort,
-            defaults.reasoning_effort,
-        )?;
-        let reasoning_effort_metadata = reasoning_effort_metadata(reasoning_effort);
-        if model_changed || entry.metadata.reasoning_effort != reasoning_effort_metadata {
+        if model_changed {
             entry.metadata.model = Some(model.clone());
-            entry.metadata.reasoning_effort = reasoning_effort_metadata;
             self.thread_index
                 .insert(entry.clone())
                 .await
@@ -621,7 +594,7 @@ impl AmpBridge {
             sandbox: sandbox_policy(sandbox_mode),
             permission_profile: params.permission_profile,
             active_permission_profile: None,
-            reasoning_effort,
+            reasoning_effort: None,
         })
     }
 
@@ -813,44 +786,10 @@ impl AmpBridge {
                 .or(entry.metadata.model.as_deref())
                 .or(defaults.model.as_deref()),
         );
-        let mut entry_changed = old_model.as_deref() != Some(mode.as_str());
+        let entry_changed = old_model.as_deref() != Some(mode.as_str());
         if entry_changed {
             entry.metadata.model = Some(mode.clone());
         }
-        let prior_turns = self
-            .all_turns(state, &params.thread_id)
-            .await
-            .map_err(|err| internal(err.to_string()))?;
-        let first_amp_message = prior_turns.is_empty() && entry.metadata.amp_thread_id.is_none();
-        let launch_effort = if first_amp_message {
-            let stored_effort = (!entry_changed)
-                .then(|| {
-                    entry
-                        .metadata
-                        .reasoning_effort
-                        .as_deref()
-                        .and_then(parse_amp_reasoning_effort)
-                })
-                .flatten();
-            let effort = select_amp_reasoning_effort(
-                &mode,
-                params.effort,
-                stored_effort,
-                defaults.reasoning_effort,
-            )?;
-            let metadata = reasoning_effort_metadata(effort);
-            if entry.metadata.reasoning_effort != metadata {
-                entry.metadata.reasoning_effort = metadata;
-                entry_changed = true;
-            }
-            if let Some(effort) = effort {
-                Some(reasoning_effort_wire_value(effort).to_string())
-            } else {
-                None
-            }
-        } else {
-            None
-        };
         let approval_policy = params
             .approval_policy
             .clone()
@@ -882,7 +821,6 @@ impl AmpBridge {
                 cwd,
                 amp_thread_id: entry.metadata.amp_thread_id.clone(),
                 mode,
-                effort: launch_effort,
                 dangerously_allow_all,
             },
         )
@@ -1913,7 +1851,7 @@ fn thread_start_response(shape: ThreadStartShape) -> p::ThreadStartResponse {
         sandbox: shape.sandbox,
         permission_profile: None,
         active_permission_profile: None,
-        reasoning_effort: shape.reasoning_effort,
+        reasoning_effort: None,
     }
 }
 
@@ -1929,16 +1867,10 @@ fn config_write_response(codex_home: &Path) -> p::ConfigWriteResponse {
     }
 }
 
-fn amp_models(include_hidden: bool) -> Vec<p::Model> {
+fn amp_models(_include_hidden: bool) -> Vec<p::Model> {
     AMP_VISIBLE_MODES
         .into_iter()
         .map(|mode| (mode, false))
-        .chain(
-            AMP_HIDDEN_MODES
-                .into_iter()
-                .filter(move |_| include_hidden)
-                .map(|mode| (mode, true)),
-        )
         .map(|(model, hidden)| p::Model {
             id: model.to_string(),
             model: model.to_string(),
@@ -1948,14 +1880,8 @@ fn amp_models(include_hidden: bool) -> Vec<p::Model> {
             display_name: model.to_string(),
             description: amp_mode_description(model).to_string(),
             hidden,
-            supported_reasoning_efforts: supported_amp_reasoning_efforts(model)
-                .map(|effort| p::ReasoningEffortOption {
-                    reasoning_effort: effort,
-                    description: format!("{effort:?}"),
-                })
-                .collect(),
-            default_reasoning_effort: default_amp_reasoning_effort(model)
-                .unwrap_or(p::ReasoningEffort::None),
+            supported_reasoning_efforts: Vec::new(),
+            default_reasoning_effort: p::ReasoningEffort::None,
             input_modalities: vec![
                 Value::String("text".to_string()),
                 Value::String("image".to_string()),
@@ -1968,8 +1894,7 @@ fn amp_models(include_hidden: bool) -> Vec<p::Model> {
         .collect()
 }
 
-const AMP_VISIBLE_MODES: [&str; 3] = ["smart", "rush", "deep"];
-const AMP_HIDDEN_MODES: [&str; 1] = ["large"];
+const AMP_VISIBLE_MODES: [&str; 4] = ["low", "medium", "high", "ultra"];
 
 fn normalize_model(model: Option<&str>) -> String {
     let mode = model
@@ -1982,119 +1907,27 @@ fn normalize_model(model: Option<&str>) -> String {
         })
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| DEFAULT_MODEL.to_string());
-    if is_supported_amp_mode(&mode) {
-        mode
-    } else {
-        DEFAULT_MODEL.to_string()
+    match mode.as_str() {
+        "rush" => "low".to_string(),
+        "smart" | "deep" => "medium".to_string(),
+        "large" => "ultra".to_string(),
+        _ if is_supported_amp_mode(&mode) => mode,
+        _ => DEFAULT_MODEL.to_string(),
     }
 }
 
 fn is_supported_amp_mode(mode: &str) -> bool {
-    AMP_VISIBLE_MODES.contains(&mode) || AMP_HIDDEN_MODES.contains(&mode)
+    AMP_VISIBLE_MODES.contains(&mode)
 }
 
 fn amp_mode_description(mode: &str) -> &'static str {
     match mode {
-        "smart" => "State-of-the-art, unconstrained Amp mode",
-        "rush" => "Faster and cheaper for small, well-defined tasks",
-        "deep" => "Deep reasoning with GPT-5.5",
-        "large" => "Hidden large-context Amp mode",
+        "low" => "Fast responses for simple, well-defined tasks.",
+        "medium" => "Balanced performance for everyday coding tasks.",
+        "high" => "More reasoning for complex coding tasks.",
+        "ultra" => "Maximum capability for the hardest coding tasks.",
         _ => "Amp agent mode",
     }
-}
-
-fn supported_amp_reasoning_efforts(mode: &str) -> impl Iterator<Item = p::ReasoningEffort> {
-    match mode {
-        "smart" => vec![p::ReasoningEffort::High, p::ReasoningEffort::XHigh],
-        "deep" => vec![
-            p::ReasoningEffort::Low,
-            p::ReasoningEffort::Medium,
-            p::ReasoningEffort::XHigh,
-        ],
-        _ => Vec::new(),
-    }
-    .into_iter()
-}
-
-fn default_amp_reasoning_effort(mode: &str) -> Option<p::ReasoningEffort> {
-    match mode {
-        "smart" => Some(p::ReasoningEffort::High),
-        "deep" => Some(p::ReasoningEffort::Medium),
-        _ => None,
-    }
-}
-
-fn parse_amp_reasoning_effort(value: &str) -> Option<p::ReasoningEffort> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "none" => Some(p::ReasoningEffort::None),
-        "minimal" => Some(p::ReasoningEffort::Minimal),
-        "low" => Some(p::ReasoningEffort::Low),
-        "medium" => Some(p::ReasoningEffort::Medium),
-        "high" => Some(p::ReasoningEffort::High),
-        "xhigh" | "x-high" => Some(p::ReasoningEffort::XHigh),
-        "max" => Some(p::ReasoningEffort::Max),
-        _ => None,
-    }
-}
-
-fn amp_effort_from_additional(additional: &HashMap<String, Value>) -> Option<p::ReasoningEffort> {
-    additional
-        .get("effort")
-        .and_then(Value::as_str)
-        .and_then(parse_amp_reasoning_effort)
-}
-
-fn reasoning_effort_metadata(effort: Option<p::ReasoningEffort>) -> Option<String> {
-    effort.map(reasoning_effort_wire_value).map(str::to_string)
-}
-
-fn select_amp_reasoning_effort(
-    mode: &str,
-    requested: Option<p::ReasoningEffort>,
-    stored: Option<p::ReasoningEffort>,
-    default: Option<p::ReasoningEffort>,
-) -> Result<Option<p::ReasoningEffort>, JsonRpcError> {
-    if let Some(effort) = requested {
-        ensure_supported_amp_effort(mode, effort)?;
-        return Ok((effort != p::ReasoningEffort::None).then_some(effort));
-    }
-    if let Some(effort) = stored.filter(|effort| is_supported_amp_effort(mode, *effort)) {
-        return Ok((effort != p::ReasoningEffort::None).then_some(effort));
-    }
-    if let Some(effort) = default.filter(|effort| is_supported_amp_effort(mode, *effort)) {
-        return Ok((effort != p::ReasoningEffort::None).then_some(effort));
-    }
-    Ok(default_amp_reasoning_effort(mode))
-}
-
-fn reasoning_effort_wire_value(effort: p::ReasoningEffort) -> &'static str {
-    match effort {
-        p::ReasoningEffort::None => "none",
-        p::ReasoningEffort::Minimal => "minimal",
-        p::ReasoningEffort::Low => "low",
-        p::ReasoningEffort::Medium => "medium",
-        p::ReasoningEffort::High => "high",
-        p::ReasoningEffort::XHigh => "xhigh",
-        p::ReasoningEffort::Max => "max",
-    }
-}
-
-fn ensure_supported_amp_effort(mode: &str, effort: p::ReasoningEffort) -> Result<(), JsonRpcError> {
-    if is_supported_amp_effort(mode, effort) {
-        Ok(())
-    } else {
-        Err(invalid_params(format!(
-            "amp mode `{mode}` does not support effort `{}`",
-            reasoning_effort_wire_value(effort)
-        )))
-    }
-}
-
-fn is_supported_amp_effort(mode: &str, effort: p::ReasoningEffort) -> bool {
-    if effort == p::ReasoningEffort::None {
-        return supported_amp_reasoning_efforts(mode).next().is_none();
-    }
-    supported_amp_reasoning_efforts(mode).any(|supported| supported == effort)
 }
 
 fn default_approval_policy(dangerously_allow_all: bool) -> p::AskForApproval {
@@ -2192,5 +2025,48 @@ fn method_not_found(method: &str) -> JsonRpcError {
         code: error_codes::METHOD_NOT_FOUND,
         message: format!("method `{method}` is not implemented"),
         data: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_current_and_legacy_amp_modes() {
+        for mode in AMP_VISIBLE_MODES {
+            assert_eq!(normalize_model(Some(mode)), mode);
+        }
+        assert_eq!(normalize_model(None), "medium");
+        assert_eq!(normalize_model(Some("rush")), "low");
+        assert_eq!(normalize_model(Some("smart")), "medium");
+        assert_eq!(normalize_model(Some("deep")), "medium");
+        assert_eq!(normalize_model(Some("large")), "ultra");
+        assert_eq!(normalize_model(Some("amp:SMART")), "medium");
+    }
+
+    #[test]
+    fn stream_input_uses_only_documented_fields() {
+        let envelope = translate_user_input(
+            &[p::UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            false,
+        )
+        .unwrap();
+        let fields = envelope.as_object().unwrap().keys().collect::<Vec<_>>();
+        assert_eq!(fields, vec!["message", "type"]);
+
+        let steered = translate_user_input(
+            &[p::UserInput::Text {
+                text: "more".to_string(),
+                text_elements: Vec::new(),
+            }],
+            true,
+        )
+        .unwrap();
+        let fields = steered.as_object().unwrap().keys().collect::<Vec<_>>();
+        assert_eq!(fields, vec!["message", "steer", "type"]);
     }
 }

--- a/crates/amp-bridge/src/index.rs
+++ b/crates/amp-bridge/src/index.rs
@@ -305,6 +305,20 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[test]
+    fn legacy_session_metadata_with_reasoning_effort_remains_readable() {
+        let metadata: AmpSessionRef = serde_json::from_value(json!({
+            "ampThreadId": "T-legacy",
+            "model": "smart",
+            "reasoningEffort": "xhigh"
+        }))
+        .unwrap();
+
+        assert_eq!(metadata.amp_thread_id.as_deref(), Some("T-legacy"));
+        assert_eq!(metadata.model.as_deref(), Some("smart"));
+        assert_eq!(metadata.reasoning_effort.as_deref(), Some("xhigh"));
+    }
+
     async fn write_native_amp_thread(dir: &Path, id: &str, title: &str) -> PathBuf {
         let path = dir.join(format!("{id}.json"));
         tokio::fs::write(

--- a/crates/amp-bridge/src/process.rs
+++ b/crates/amp-bridge/src/process.rs
@@ -21,7 +21,6 @@ pub struct AmpSpawnConfig {
     pub cwd: PathBuf,
     pub amp_thread_id: Option<String>,
     pub mode: String,
-    pub effort: Option<String>,
     pub dangerously_allow_all: bool,
 }
 
@@ -85,7 +84,6 @@ impl AmpProcess {
             cwd,
             amp_thread_id,
             mode,
-            effort,
             dangerously_allow_all,
         } = config;
 
@@ -101,10 +99,6 @@ impl AmpProcess {
         if !mode.trim().is_empty() {
             args.push("--mode".into());
             args.push(mode.into());
-        }
-        if let Some(effort) = effort.filter(|value| !value.trim().is_empty()) {
-            args.push("--effort".into());
-            args.push(effort.into());
         }
         args.push("--execute".into());
         args.push("--stream-json".into());

--- a/crates/amp-bridge/src/state.rs
+++ b/crates/amp-bridge/src/state.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, Mutex};
 use alleycat_bridge_core::ProcessLauncher;
 use alleycat_bridge_core::session::Session;
 use alleycat_codex_proto::{
-    ApprovalsReviewer, AskForApproval, InitializeCapabilities, JsonRpcMessage, ReasoningEffort,
-    SandboxMode, ThreadItem, Turn, TurnError, TurnStatus,
+    ApprovalsReviewer, AskForApproval, InitializeCapabilities, JsonRpcMessage, SandboxMode,
+    ThreadItem, Turn, TurnError, TurnStatus,
 };
 use serde_json::Value;
 
@@ -44,7 +44,6 @@ pub struct RecordedTurn {
 pub struct ThreadDefaults {
     pub model: Option<String>,
     pub model_provider: Option<String>,
-    pub reasoning_effort: Option<ReasoningEffort>,
     pub approval_policy: Option<AskForApproval>,
     pub approvals_reviewer: Option<ApprovalsReviewer>,
     pub sandbox: Option<SandboxMode>,

--- a/crates/amp-bridge/tests/fake_amp_smoke.rs
+++ b/crates/amp-bridge/tests/fake_amp_smoke.rs
@@ -39,19 +39,12 @@ case " $* " in
   *" threads continue T-fake-amp "*) continuing=1 ;;
 esac
 case " $* " in
-  *" --mode smart "*) ;;
-  *) echo "missing --mode smart in amp argv: $*" >&2; exit 7 ;;
+  *" --mode medium "*) ;;
+  *) echo "missing --mode medium in amp argv: $*" >&2; exit 7 ;;
 esac
-if [[ "$continuing" == "1" ]]; then
-  case " $* " in
-    *" --effort "*) echo "unexpected --effort on continued amp thread argv: $*" >&2; exit 8 ;;
-  esac
-else
-  case " $* " in
-    *" --effort high "*) ;;
-    *) echo "missing --effort high in amp argv: $*" >&2; exit 8 ;;
-  esac
-fi
+case " $* " in
+  *" --effort "*) echo "unexpected --effort in amp argv: $*" >&2; exit 8 ;;
+esac
 case " $* " in
   *" --stream-json-thinking "*) ;;
   *) echo "missing --stream-json-thinking in amp argv: $*" >&2; exit 9 ;;
@@ -65,11 +58,11 @@ if [[ "$continuing" == "1" ]]; then
 else
   text="hello from fake amp"
 fi
-echo '{"type":"system","subtype":"init","cwd":"/tmp/fake","session_id":"T-fake-amp","tools":["Bash"],"mcp_servers":[]}'
+echo '{"type":"system","subtype":"init","cwd":"/tmp/fake","session_id":"T-fake-amp","tools":["Bash"],"mcp_servers":[],"agent_mode":"medium","future_field":{"safe_to_ignore":true}}'
 printf '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello amp"}]},"parent_tool_use_id":null,"session_id":"T-fake-amp"}\n'
 printf '{"type":"assistant","message":{"type":"message","role":"assistant","content":[{"type":"text","text":"%s"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":2,"max_tokens":100}},"parent_tool_use_id":null,"session_id":"T-fake-amp"}\n' "$text"
 cat >/dev/null || true
-printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"num_turns":1,"result":"%s","session_id":"T-fake-amp","usage":{"input_tokens":1,"output_tokens":2,"max_tokens":100}}\n' "$text"
+printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"num_turns":1,"result":"%s","session_id":"T-fake-amp","usage":{"input_tokens":1,"output_tokens":2,"max_tokens":100},"permission_denials":[]}\n' "$text"
 "#,
     )
     .unwrap();
@@ -112,18 +105,17 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
         .iter()
         .map(|model| model["id"].as_str().unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(model_ids, vec!["smart", "rush", "deep"]);
-    let smart = &models["result"]["data"][0];
-    assert_eq!(smart["displayName"], "smart");
-    assert_eq!(
-        smart["supportedReasoningEfforts"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|option| option["reasoningEffort"].as_str().unwrap())
-            .collect::<Vec<_>>(),
-        vec!["high", "xhigh"]
-    );
+    assert_eq!(model_ids, vec!["low", "medium", "high", "ultra"]);
+    for model in models["result"]["data"].as_array().unwrap() {
+        assert_eq!(model["defaultReasoningEffort"], "none");
+        assert!(
+            model["supportedReasoningEfforts"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+    }
+    assert_eq!(models["result"]["data"][1]["isDefault"], true);
 
     send_request(
         &mut writer,
@@ -139,28 +131,20 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
         .iter()
         .map(|model| model["id"].as_str().unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(hidden_model_ids, vec!["smart", "rush", "deep", "large"]);
-    let large = hidden_models["result"]["data"].as_array().unwrap()[3].clone();
-    assert_eq!(large["hidden"], true);
-    assert_eq!(large["defaultReasoningEffort"], "none");
-    assert_eq!(
-        large["supportedReasoningEfforts"].as_array().unwrap().len(),
-        0
-    );
+    assert_eq!(hidden_model_ids, vec!["low", "medium", "high", "ultra"]);
 
     send_request(
         &mut writer,
         3,
         "thread/start",
         json!({
-            "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "cwd": temp.path().to_string_lossy()
         }),
     )
     .await;
     let thread_start = assert_response(&mut lines, 3).await;
-    assert_eq!(thread_start["result"]["model"], "smart");
-    assert_eq!(thread_start["result"]["reasoningEffort"], "high");
+    assert_eq!(thread_start["result"]["model"], "medium");
+    assert!(thread_start["result"]["reasoningEffort"].is_null());
     let thread_id = thread_start["result"]["thread"]["id"]
         .as_str()
         .unwrap()
@@ -280,7 +264,7 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
 }
 
 #[tokio::test]
-async fn fake_amp_hidden_large_mode_launches_without_effort() {
+async fn fake_amp_legacy_large_mode_normalizes_to_ultra() {
     let temp = TempDir::new().unwrap();
     let fake_amp = temp.path().join("fake-amp-large.sh");
     std::fs::write(
@@ -288,8 +272,8 @@ async fn fake_amp_hidden_large_mode_launches_without_effort() {
         r#"#!/usr/bin/env bash
 set -euo pipefail
 case " $* " in
-  *" --mode large "*) ;;
-  *) echo "missing --mode large in amp argv: $*" >&2; exit 7 ;;
+  *" --mode ultra "*) ;;
+  *) echo "missing --mode ultra in amp argv: $*" >&2; exit 7 ;;
 esac
 case " $* " in
   *" --effort "*) echo "unexpected --effort for large mode argv: $*" >&2; exit 8 ;;
@@ -347,7 +331,7 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
     )
     .await;
     let thread_start = assert_response(&mut lines, 2).await;
-    assert_eq!(thread_start["result"]["model"], "large");
+    assert_eq!(thread_start["result"]["model"], "ultra");
     assert!(thread_start["result"]["reasoningEffort"].is_null());
     let thread_id = thread_start["result"]["thread"]["id"]
         .as_str()
@@ -391,7 +375,7 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
 }
 
 #[tokio::test]
-async fn fake_amp_mode_change_clears_incompatible_effort_before_first_turn() {
+async fn fake_amp_legacy_mode_and_stale_effort_are_normalized_and_ignored() {
     let temp = TempDir::new().unwrap();
     let fake_amp = temp.path().join("fake-amp-rush.sh");
     std::fs::write(
@@ -399,8 +383,8 @@ async fn fake_amp_mode_change_clears_incompatible_effort_before_first_turn() {
         r#"#!/usr/bin/env bash
 set -euo pipefail
 case " $* " in
-  *" --mode rush "*) ;;
-  *) echo "missing --mode rush in amp argv: $*" >&2; exit 7 ;;
+  *" --mode low "*) ;;
+  *) echo "missing --mode low in amp argv: $*" >&2; exit 7 ;;
 esac
 case " $* " in
   *" --effort "*) echo "unexpected --effort for rush mode argv: $*" >&2; exit 8 ;;
@@ -453,12 +437,12 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
         "thread/start",
         json!({
             "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "model": "medium"
         }),
     )
     .await;
     let thread_start = assert_response(&mut lines, 2).await;
-    assert_eq!(thread_start["result"]["reasoningEffort"], "high");
+    assert!(thread_start["result"]["reasoningEffort"].is_null());
     let thread_id = thread_start["result"]["thread"]["id"]
         .as_str()
         .unwrap()
@@ -475,7 +459,7 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
     )
     .await;
     let thread_resume = assert_response(&mut lines, 3).await;
-    assert_eq!(thread_resume["result"]["model"], "rush");
+    assert_eq!(thread_resume["result"]["model"], "low");
     assert!(thread_resume["result"]["reasoningEffort"].is_null());
 
     send_request(
@@ -522,6 +506,13 @@ async fn fake_amp_exit_without_result_fails_turn() {
         &fake_amp,
         r#"#!/usr/bin/env bash
 set -euo pipefail
+case " $* " in
+  *" --mode high "*) ;;
+  *) echo "missing --mode high in amp argv: $*" >&2; exit 7 ;;
+esac
+case " $* " in
+  *" --effort "*) echo "unexpected --effort in high mode argv: $*" >&2; exit 8 ;;
+esac
 first=""
 if IFS= read -r first; then
   :
@@ -568,7 +559,7 @@ exit 12
         "thread/start",
         json!({
             "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "model": "high"
         }),
     )
     .await;
@@ -782,7 +773,7 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
         "thread/start",
         json!({
             "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "model": "medium"
         }),
     )
     .await;
@@ -874,7 +865,7 @@ async fn fake_amp_initial_write_failure_clears_active_turn() {
         "thread/start",
         json!({
             "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "model": "medium"
         }),
     )
     .await;
@@ -956,7 +947,7 @@ sleep 30
         "thread/start",
         json!({
             "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "model": "medium"
         }),
     )
     .await;
@@ -1085,7 +1076,7 @@ printf '{"type":"result","subtype":"success","duration_ms":42,"is_error":false,"
         "thread/start",
         json!({
             "cwd": temp.path().to_string_lossy(),
-            "model": "smart"
+            "model": "medium"
         }),
     )
     .await;


### PR DESCRIPTION
## Motivation

Current Amp uses `low`, `medium`, `high`, and `ultra`. Alleycat still advertised legacy modes and passed removed `--effort`, causing new turns to fail.

## Solution

- Advertise current modes with `medium` as default.
- Normalize legacy mode metadata.
- Stop forwarding effort while keeping old indexes readable.
- Preserve native thread continuation and stream-JSON behavior.

Related mobile update: https://github.com/0xSero/litter/pull/225

## Verification

- `cargo test -p alleycat-amp-bridge`
- `cargo test -p alleycat -- --test-threads=1`
- Bridge conformance and real Amp CLI smoke tests
