### PR TITLE
docs: reconcile repository and runtime surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ edition = "2024"
 license = "GPL-3.0-only"
 version = "0.1.0"
 authors = ["The Alleycat Authors"]
-repository = "https://github.com/dnakov/alleycat"
-homepage = "https://github.com/dnakov/alleycat"
+repository = "https://github.com/0xSero/alleycat"
+homepage = "https://github.com/0xSero/alleycat"
 readme = "README.md"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a paired client, and the client picks an agent over the same stream multiplexer.
 
 ## Install
 
-End-user packages are published from the [`kittylitter`](https://github.com/dnakov/litter) project, which wraps this daemon under the `kittylitter` command. The currently enabled published channel is npm/bun; Homebrew, shell installer, PowerShell installer, and MSI publishing are not enabled in the release config right now. Source installs from this repo expose the daemon as `alleycat`.
+End-user packages are published from the [`kittylitter`](https://github.com/0xSero/litter) project, which wraps this daemon under the `kittylitter` command. The currently enabled published channel is npm/bun; Homebrew, shell installer, PowerShell installer, and MSI publishing are not enabled in the release config right now. Source installs from this repo expose the daemon as `alleycat`.
 
 | Platform | Install |
 |---|---|
@@ -58,6 +58,9 @@ The command surface is the same for `kittylitter` packaged installs and `alleyca
 | `alleycat agents list` | List configured agents and their availability. |
 | `alleycat logs [-f]` | Tail the daemon log files. |
 | `alleycat stop` | Graceful shutdown via the control socket. |
+| `alleycat restart` | Restart the daemon using the current binary and refresh its autostart entry. |
+| `alleycat probe [OPTIONS]` | Connect over iroh like a phone client and exercise an agent's JSON-RPC surface. |
+| `alleycat upgrade` | Restart a stale daemon onto the version of the currently running CLI. |
 
 The daemon talks to the CLI over a Unix domain socket on macOS/Linux and a per-user named pipe on Windows. `status`, `pair`, and `rotate` round-trip through it when the daemon is up and fall back to file-only operations when it isn't, so first-run flows still work.
 
@@ -113,6 +116,12 @@ The daemon answers with `{ok, agents?, error?}`. On `connect`, after the respons
 token = "..."          # 32 bytes hex; rotate via `alleycat rotate`
 # relay = "https://..." # optional iroh relay override
 
+[session]
+replay_max_msgs = 2048
+replay_max_bytes = 16777216
+idle_ttl_secs = 600
+pending_grace_secs = 60
+
 [agents.codex]
 enabled = true
 bin = "codex"
@@ -136,6 +145,7 @@ bin = "opencode"
 [agents.claude]
 enabled = true
 bin = "claude"
+bypass_permissions = true # false forwards tool approvals to the client
 
 [agents.droid]
 enabled = true
@@ -219,7 +229,7 @@ The workspace crates are:
 - `crates/shell-bridge` — interactive shell process adapter.
 - `crates/claude-remote-control` — auxiliary Claude remote-control protocol support.
 
-Releases are produced from the [`litter`](https://github.com/dnakov/litter)
+Releases are produced from the [`litter`](https://github.com/0xSero/litter)
 repo. Litter consumes selected bridge crates through revision-pinned Git
 dependencies and packages the daemon through its `kittylitter` wrapper. A
 change on Alleycat `main` is therefore not shipped until Litter updates and

--- a/crates/alleycat/Cargo.toml
+++ b/crates/alleycat/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme.workspace = true
-description = "Iroh-backed daemon that multiplexes local coding agents (Codex, Pi, OpenCode, Claude) onto a single QUIC connection for paired clients."
+description = "Iroh-backed daemon that multiplexes local coding agents onto a single QUIC connection for paired clients."
 # Distribution happens via the `kittylitter` wrapper crate in the litter
 # repo; this crate is consumed only as a git dep.
 publish = false

--- a/crates/bridge-conformance/src/scenario.rs
+++ b/crates/bridge-conformance/src/scenario.rs
@@ -344,9 +344,8 @@ pub async fn run(
     // Step 7a: turn/start with a tool-using prompt --------------------------
     //
     // Exercises the CommandExecution / DynamicToolCall item shapes that the
-    // simple-reply turn doesn't reach. Prompt is engineered so any of the
-    // four agents picks their shell tool (claude→Bash, opencode→bash,
-    // pi→shell, codex→shell) without a thinking detour. The bridges'
+    // simple-reply turn doesn't reach. Prompt is engineered so every
+    // supported target picks its shell tool without a thinking detour. The bridges'
     // `approvalPolicy: "never"` (set on thread/start) lets the call run
     // without surfacing a server→client permission request.
     let tool_turn = client

--- a/crates/bridge-conformance/src/transport.rs
+++ b/crates/bridge-conformance/src/transport.rs
@@ -1,8 +1,8 @@
-//! Shared JSON-RPC client used by all four targets.
+//! Shared JSON-RPC client used by every conformance target.
 //!
 //! Every target produces a pair of (writer, reader) trait objects from its
-//! transport (stdio pipes for pi/claude, Unix socket for opencode, raw TCP
-//! for codex). The harness drives them through this client, which handles
+//! transport (usually stdio pipes, with backend-specific socket transports
+//! where needed). The harness drives them through this client, which handles
 //! id allocation, request/response correlation, and notification capture.
 
 use std::sync::atomic::{AtomicI64, Ordering};

--- a/crates/bridge-core/src/session/registry.rs
+++ b/crates/bridge-core/src/session/registry.rs
@@ -1,6 +1,6 @@
 //! `SessionRegistry` — the daemon-lifetime owner of all live sessions, keyed
 //! by `(node_id, agent)`. Concurrent map operations use a coarse `Mutex`; the
-//! contention is fine for our scale (handful of clients × four agents).
+//! contention is fine for our scale (a handful of clients and configured agents).
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};

--- a/crates/claude-bridge/src/bridge.rs
+++ b/crates/claude-bridge/src/bridge.rs
@@ -1,9 +1,9 @@
 //! `ClaudeBridge` — the unified `Bridge` impl.
 //!
 //! Owns the [`ClaudePool`], the disk-backed thread index, the launcher seam,
-//! and per-connection state keyed by session id. Replaces the legacy
-//! [`crate::server::run_connection_with_session`] free function (which is kept
-//! as a thin compat shim during the migration).
+//! and per-connection state keyed by session id. Production traffic uses the
+//! shared bridge-core server; [`crate::server::run_connection`] remains only as
+//! an in-process test helper.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -113,7 +113,7 @@ impl ClaudeBridge {
     }
 
     /// Internal: assemble a bridge from already-built parts. Used by the
-    /// legacy `run_connection_with_session` compat shim (see `server.rs`).
+    /// in-process `server::run_connection` test helper.
     #[doc(hidden)]
     pub fn __assemble(
         pool: Arc<ClaudePool>,

--- a/crates/claude-bridge/tests/smoke/README.md
+++ b/crates/claude-bridge/tests/smoke/README.md
@@ -1,23 +1,17 @@
 # claude-bridge smoke drivers
 
-Operator-facing smoke scripts. Not part of `cargo test` — driven by hand
-when you want to exercise the bridge against the real `claude` CLI (or a
-running `alleycat` daemon).
+Operator-facing smoke script. Not part of `cargo test` — driven by hand when
+you want to exercise the bridge against the real `claude` CLI.
 
 | Script | What it does |
 |---|---|
 | `stdio_smoke.sh` | Spawns `cargo run -p alleycat-claude-bridge` in stdio mode and feeds it a scripted JSON-RPC sequence (`initialize` → `thread/start` → `turn/start "say hi in one word"` → wait for `turn/completed`). Talks to **real claude**. Requires `claude` on `$PATH` and `jq`. |
-| `daemon_smoke.sh` | Connects to a running `alleycat` daemon via the iroh client (`alleycat probe`) and runs the same flow against the `claude` agent. Requires `alleycat serve` running in another terminal. |
 
 ## Running
 
 ```bash
 # stdio smoke against real claude:
 ./crates/claude-bridge/tests/smoke/stdio_smoke.sh
-
-# daemon-mediated:
-target/release/alleycat serve     # in another terminal
-./crates/claude-bridge/tests/smoke/daemon_smoke.sh
 ```
 
 ## CI coverage
@@ -25,5 +19,6 @@ target/release/alleycat serve     # in another terminal
 The Rust integration tests (`tests/smoke_in_process.rs`,
 `tests/smoke_binary.rs`, `tests/fake_claude_smoke.rs`) cover the same
 flow via the `fake-claude` test binary, so CI doesn't depend on a real
-`claude` install. These bash drivers are the live-claude / live-daemon
-counterparts you run before tagging a release.
+`claude` install. The shell driver is the live-Claude counterpart to run
+before tagging a release. Use `alleycat probe --agent claude` for an
+operator-driven daemon path.


### PR DESCRIPTION
## Purpose

Bring operator, package, and source documentation back in sync with the repository and the current ten-agent runtime.

## Changes

- replace stale `dnakov` repository/package links with the authoritative `0xSero` locations
- make the crate description accurate without freezing an incomplete agent list
- document the live `restart`, `probe`, and `upgrade` commands
- document all session replay/retention settings and Claude permission forwarding
- remove references to the nonexistent `daemon_smoke.sh` and point daemon testing at `alleycat probe`
- update stale source documentation that still described four conformance targets or a removed Claude helper name

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --offline --locked`
- stale-reference sweeps for old owners, missing scripts, removed helper names, and four-target wording
- `git diff --check`
