### PR TITLE
fix(pi): emit token usage notifications so the context meter works for pi sessions

### DIFF
--- a/crates/pi-bridge/src/translate/events.rs
+++ b/crates/pi-bridge/src/translate/events.rs
@@ -22,7 +22,9 @@ use std::collections::HashMap;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::codex_proto::common::{TurnError, TurnStatus};
+use crate::codex_proto::common::{
+    ThreadTokenUsage, TokenUsageBreakdown, TurnError, TurnStatus,
+};
 use crate::codex_proto::items::{
     CommandExecutionStatus, DynamicToolCallStatus, FileUpdateChange, McpToolCallError,
     McpToolCallResult, McpToolCallStatus, PatchApplyStatus, PatchChangeKind, ThreadItem,
@@ -31,7 +33,7 @@ use crate::codex_proto::notifications::{
     AgentMessageDeltaNotification, CommandExecutionOutputDeltaNotification,
     ContextCompactedNotification, ErrorNotification, ItemCompletedNotification,
     ItemStartedNotification, McpToolCallProgressNotification, ReasoningTextDeltaNotification,
-    ServerNotification,
+    ServerNotification, ThreadTokenUsageUpdatedNotification,
 };
 use crate::pool::pi_protocol::{
     AgentMessage, AssistantContentBlock, AssistantMessage, AssistantMessageEvent, PiEvent,
@@ -54,6 +56,7 @@ pub struct EventTranslatorState {
     open_reasoning_item: Option<OpenItem>,
     open_tool_calls: HashMap<String, OpenToolCall>,
     open_compaction_item_id: Option<String>,
+    cumulative_token_usage: TokenUsageBreakdown,
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +97,7 @@ impl EventTranslatorState {
             open_reasoning_item: None,
             open_tool_calls: HashMap::new(),
             open_compaction_item_id: None,
+            cumulative_token_usage: TokenUsageBreakdown::default(),
         }
     }
 
@@ -111,7 +115,7 @@ impl EventTranslatorState {
             PiEvent::AgentStart => Vec::new(),
             PiEvent::TurnStart => Vec::new(),
             PiEvent::AgentEnd { .. } => self.translate_agent_end(),
-            PiEvent::TurnEnd { .. } => Vec::new(),
+            PiEvent::TurnEnd { message, .. } => self.translate_turn_end(message),
             PiEvent::ThinkingLevelChanged { .. } => Vec::new(),
 
             PiEvent::MessageStart { message } => match message {
@@ -645,6 +649,34 @@ impl EventTranslatorState {
         out
     }
 
+    fn translate_turn_end(&mut self, message: AgentMessage) -> Vec<ServerNotification> {
+        let AgentMessage::Assistant(a) = &message else {
+            return Vec::new();
+        };
+        if a.usage.total_tokens == 0 && a.usage.input == 0 && a.usage.output == 0 {
+            return Vec::new();
+        }
+        let breakdown = TokenUsageBreakdown {
+            total_tokens: a.usage.total_tokens as i64,
+            input_tokens: a.usage.input as i64,
+            cached_input_tokens: a.usage.cache_read as i64,
+            output_tokens: a.usage.output as i64,
+            reasoning_output_tokens: 0,
+        };
+        self.cumulative_token_usage = sum_breakdown(&self.cumulative_token_usage, &breakdown);
+        vec![ServerNotification::ThreadTokenUsageUpdated(
+            ThreadTokenUsageUpdatedNotification {
+                thread_id: self.thread_id.clone(),
+                turn_id: self.turn_id.clone(),
+                token_usage: ThreadTokenUsage {
+                    total: self.cumulative_token_usage.clone(),
+                    last: breakdown,
+                    model_context_window: None,
+                },
+            },
+        )]
+    }
+
     fn translate_agent_end(&mut self) -> Vec<ServerNotification> {
         let mut out = Vec::new();
         if let Some(item) = self.open_message_item.take()
@@ -1146,6 +1178,75 @@ mod tests {
             stop_reason: StopReason::Stop,
             error_message: None,
             timestamp: 0,
+        }
+    }
+
+    fn assistant_msg_with_usage(input: u64, output: u64, cache_read: u64) -> AgentMessage {
+        AgentMessage::Assistant(AssistantMessage {
+            usage: Usage {
+                input,
+                output,
+                cache_read,
+                cache_write: 0,
+                total_tokens: input + output + cache_read,
+                cost: UsageCost {
+                    input: 0.0,
+                    output: 0.0,
+                    cache_read: 0.0,
+                    cache_write: 0.0,
+                    total: 0.0,
+                },
+            },
+            ..assistant_message("")
+        })
+    }
+
+    #[test]
+    fn turn_end_with_usage_emits_thread_token_usage_updated() {
+        let mut s = state();
+        let out = s.translate(PiEvent::TurnEnd {
+            message: assistant_msg_with_usage(300, 200, 100),
+            tool_results: Vec::new(),
+        });
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            ServerNotification::ThreadTokenUsageUpdated(n) => {
+                assert_eq!(n.thread_id, "th_1");
+                assert_eq!(n.turn_id, "tu_1");
+                assert_eq!(n.token_usage.last.total_tokens, 600);
+                assert_eq!(n.token_usage.total.total_tokens, 600);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_end_zero_usage_is_silent() {
+        let mut s = state();
+        let out = s.translate(PiEvent::TurnEnd {
+            message: assistant_msg_with_usage(0, 0, 0),
+            tool_results: Vec::new(),
+        });
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn turn_end_usage_accumulates_across_turns() {
+        let mut s = state();
+        s.translate(PiEvent::TurnEnd {
+            message: assistant_msg_with_usage(300, 200, 100),
+            tool_results: Vec::new(),
+        });
+        let out = s.translate(PiEvent::TurnEnd {
+            message: assistant_msg_with_usage(100, 100, 0),
+            tool_results: Vec::new(),
+        });
+        match &out[0] {
+            ServerNotification::ThreadTokenUsageUpdated(n) => {
+                assert_eq!(n.token_usage.last.total_tokens, 200);
+                assert_eq!(n.token_usage.total.total_tokens, 800);
+            }
+            other => panic!("unexpected {other:?}"),
         }
     }
 
@@ -1860,5 +1961,15 @@ mod tests {
             }
             other => panic!("unexpected {other:?}"),
         }
+    }
+}
+
+fn sum_breakdown(a: &TokenUsageBreakdown, b: &TokenUsageBreakdown) -> TokenUsageBreakdown {
+    TokenUsageBreakdown {
+        total_tokens: a.total_tokens + b.total_tokens,
+        input_tokens: a.input_tokens + b.input_tokens,
+        cached_input_tokens: a.cached_input_tokens + b.cached_input_tokens,
+        output_tokens: a.output_tokens + b.output_tokens,
+        reasoning_output_tokens: a.reasoning_output_tokens + b.reasoning_output_tokens,
     }
 }


### PR DESCRIPTION
fixes the 0/0 context meter for pi sessions (0xSero/litter#337). the pi bridge discards the events that carry token usage, so the meter never receives data for pi. this adds the same translation the claude bridge already has: cumulative usage totals emitted as ThreadTokenUsageUpdated on turn end, zero usage stays a no-op. unit tests included.